### PR TITLE
fix(container): update image registry.k8s.io/git-sync/git-sync to v4.7.1

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
             image:
               # renovate: datasource=docker
               repository: registry.k8s.io/git-sync/git-sync
-              tag: v4.7.0@sha256:d232fd13474ba1b46dba431af2b1411b9d9afacda55ae644d2a32e43975128dd
+              tag: v4.7.1@sha256:c5e1976da735bf0b53979f079a07475d77174c51863cd084e928ff6074480717
             env:
               GITSYNC_REPO: https://github.com/KBlixt/subcleaner
               GITSYNC_REF: master


### PR DESCRIPTION
Recreates Renovate #1113 (auto-closed by renovate[bot] after #1108 merged the same bazarr helmrelease). Bumps git-sync v4.7.0 -> v4.7.1, identical target digest.