### PR TITLE
fix(ci): full-history checkout for gitleaks PR scans

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -24,8 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Full history for scheduled scan; PRs only need the diff range
-          fetch-depth: ${{ github.event_name == 'schedule' && 0 || 1 }}
+          # Full history required: gitleaks-action diffs PRs as `base^..head`,
+          # so the base commit (and its parent) must be present in the clone.
+          # A shallow (depth 1) checkout omits it and the scan fails with
+          # "unknown revision or path not in the working tree".
+          fetch-depth: 0
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v3


### PR DESCRIPTION
Gitleaks has been failing on every PR (red check) even though no secrets are present.

**Root cause:** `gitleaks-action` scans a PR by diffing `base^..head`. The workflow checked out with `fetch-depth: 1`, so the base commit (and its parent) aren't in the shallow clone — `git log base^..head` fails with `fatal: ambiguous argument ... unknown revision`, and the action exits non-zero.

**Fix:** `fetch-depth: 0` (full history) so the diff range resolves. This PR's own Gitleaks check validates the fix.