### PR TITLE
Revert k8s v1.36.3 upgrade (pause: Ceph degraded)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.3
+    version: v1.36.2
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.36.3
+kubernetesVersion: v1.36.2
 
 clusterName: "home-kubernetes"
 endpoint: https://192.168.5.45:6443


### PR DESCRIPTION
Reverts #1117 to set the tuppr KubernetesUpgrade target back to v1.36.2 so the upgrade stops pending while we recover Ceph.

**Why:** the upgrade was correctly gated by tuppr's Ceph HEALTH_OK health check and never drained a node. Ceph is degraded (4/8 OSDs down, mon-j crashlooping, ~14% objects degraded) following the rook-ceph v1.20.2 operator upgrade (#993/#994) that Flux rolled back. Pausing the k8s upgrade de-clutters while the storage incident is resolved.

Re-apply the v1.36.3 bump once Ceph is HEALTH_OK again.