### PR TITLE
Re-apply k8s v1.36.3 upgrade (Ceph recovered)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.2
+    version: v1.36.3
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.36.2
+kubernetesVersion: v1.36.3
 
 clusterName: "home-kubernetes"
 endpoint: https://192.168.5.45:6443


### PR DESCRIPTION
Reverts #1127 to re-apply the Kubernetes v1.36.3 bump (originally #1117), now that the Ceph incident is fully resolved.

Ceph is HEALTH_OK: rook-ceph operator on v1.20.2, all daemons converged to tentacle v20.2.2, mon quorum 3/3, dead osd-2 (failed NVMe) purged, all PGs active+clean. tuppr's Ceph HEALTH_OK health-gate will now pass, so the control-plane/kubelet upgrade to v1.36.3 can proceed.