### PR TITLE
Add blackbox-exporter for ICMP latency/loss trends

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app blackbox-exporter
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: prometheus-blackbox-exporter
+      version: 11.15.1
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+  values:
+    fullnameOverride: *app
+    # ICMP probes need raw sockets; grant NET_RAW to the (non-root) container.
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        add: ["NET_RAW"]
+        drop: ["ALL"]
+    config:
+      modules:
+        icmp:
+          prober: icmp
+          timeout: 5s
+          icmp:
+            preferred_ip_protocol: ip4
+        http_2xx:
+          prober: http
+          timeout: 5s
+          http:
+            preferred_ip_protocol: ip4
+            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+    # Probe CRD (probe.yaml) drives what gets probed; the built-in serviceMonitor
+    # only scrapes the exporter's own metrics.
+    serviceMonitor:
+      enabled: true
+  driftDetection:
+    mode: enabled

--- a/kubernetes/apps/observability/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./probe.yaml

--- a/kubernetes/apps/observability/blackbox-exporter/app/probe.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probe.yaml
@@ -1,0 +1,30 @@
+# ICMP latency/loss trends. Auto-scraped by kube-prometheus-stack
+# (probeSelectorNilUsesHelmValues: false). Yields probe_success,
+# probe_duration_seconds, probe_icmp_duration_seconds per target.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-icmp
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: blackbox-exporter
+spec:
+  interval: 30s
+  module: icmp
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - 1.1.1.1 # internet — Cloudflare (WAN quality / packet loss trend)
+        - 8.8.8.8 # internet — Google
+        - 192.168.5.1 # OPNsense — LAN gateway
+        - 192.168.5.10 # truenas
+        - 192.168.5.2 # adguard — DNS resolver
+        - 192.168.5.172 # plex
+      labels:
+        probe: icmp
+      relabelingConfigs:
+        - sourceLabels: [__param_target]
+          targetLabel: instance

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app blackbox-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/observability/blackbox-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./adguard-exporter/ks.yaml
+  - ./blackbox-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana/ks.yaml
   - ./kube-prometheus-stack/ks.yaml


### PR DESCRIPTION
## What

Adds `prometheus-blackbox-exporter` to the observability stack plus a `Probe` CRD that continuously pings a handful of targets, so Prometheus/Grafana get **latency and packet-loss trends** over time.

### Targets (ICMP, every 30s)
| Target | Why |
|--------|-----|
| 1.1.1.1, 8.8.8.8 | Internet / WAN quality — packet-loss & latency trend (relevant behind CGNAT) |
| 192.168.5.1 | OPNsense LAN gateway |
| 192.168.5.10 / .2 / .172 | truenas / adguard / plex reachability |

### How it wires in
- Standard app layout (`ks.yaml` + `app/` with helmrelease/kustomization), registered in `observability/kustomization.yaml`. Mirrors `smartctl-exporter` (same `prometheus-community` HelmRepository).
- The `Probe` CRD is auto-discovered — kube-prometheus-stack already sets `probeSelectorNilUsesHelmValues: false`, so no Prometheus config change needed.
- Metrics produced: `probe_success`, `probe_duration_seconds`, `probe_icmp_duration_seconds` (labelled by `instance`).
- `NET_RAW` added for raw-socket ICMP; container remains non-root / read-only-rootfs.

## Notes
- **Chart pinned to 11.15.1** (current as of filing) — bump if Renovate/your index differs.
- No alerts or dashboard included (kept minimal per request — this is the data-collection layer). Natural follow-ups: import the Blackbox Grafana dashboard, and add a PrometheusRule for sustained `probe_success == 0` or high loss. The internet targets will flap on any real ISP blip, so tune alert thresholds before enabling paging.
- An `http_2xx` module is defined too (unused by the current Probe) for easy HTTP probes later.

## Validation
- All YAML parses (HelmRelease / Probe / Kustomizations).
- Follows the merged `node-exporter-lab` / `smartctl-exporter` conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)