### PR TITLE
fix(rook-ceph): add missing CSI ctrlplugin/nodeplugin ServiceAccounts + RBAC

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/csi-rbac.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/csi-rbac.yaml
@@ -1,0 +1,963 @@
+# Per-driver CSI ServiceAccounts + RBAC for ceph-csi-operator v1.0.4 (CSI_SERVICE_ACCOUNT_PREFIX="" in ns rook-ceph).
+#
+# WHY THIS EXISTS: the rook-ceph v1.20 CSI migration references these per-driver ServiceAccounts by name in the
+# ctrlplugin/nodeplugin workloads but neither the operator nor its subchart creates them, leaving the CSI controllers
+# stuck at 0/2 (no volume provisioning/snapshots cluster-wide). These manifests supply the missing SAs + RBAC.
+# Remove if/when the upstream chart ships them to avoid duplication.
+#
+# Rules copied verbatim from ceph-csi-operator v1.0.4:
+#   github.com/ceph/ceph-csi-operator/tree/v1.0.4/deploy/charts/ceph-csi-drivers/templates/
+#   {rbd,cephfs}-{ctrlplugin,nodeplugin}-{cr,crb,r,rb}-rbac.yaml and serviceaccount.yaml
+# Rendered with serviceAccountPrefix="" (so SA names are unprefixed) and Release.Namespace=rook-ceph.
+# Driver name normalization: rbd -> rbd, cephfs -> cephfs.
+# Cross-checked against rook v1.20.2 deploy/examples/csi-operator.yaml (identical rule sets;
+# rook example only differs by using a "ceph-csi-" SA name prefix).
+#
+# Every object carries label app.kubernetes.io/managed-by: manual-csi-rbac-fix
+---
+# ============================ ServiceAccounts ============================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cephfs-ctrlplugin-sa
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cephfs-nodeplugin-sa
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+---
+# ======================= RBD ctrlplugin ClusterRole =====================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-ctrlplugin-cr
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationcontents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cbt.storage.k8s.io
+  resources:
+  - snapshotmetadataservices
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+# ==================== RBD ctrlplugin ClusterRoleBinding =================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-ctrlplugin-crb
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-ctrlplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+# ========================= RBD ctrlplugin Role ==========================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbd-ctrlplugin-r
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+# ====================== RBD ctrlplugin RoleBinding ======================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbd-ctrlplugin-rb
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-ctrlplugin-r
+subjects:
+- kind: ServiceAccount
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+# ======================= RBD nodeplugin ClusterRole =====================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-nodeplugin-cr
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+---
+# ==================== RBD nodeplugin ClusterRoleBinding =================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-nodeplugin-crb
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-nodeplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+---
+# ========================= RBD nodeplugin Role ==========================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbd-nodeplugin-r
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+# ====================== RBD nodeplugin RoleBinding ======================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbd-nodeplugin-rb
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+---
+# ====================== CephFS ctrlplugin ClusterRole ===================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cephfs-ctrlplugin-cr
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationcontents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+# =================== CephFS ctrlplugin ClusterRoleBinding ===============
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cephfs-ctrlplugin-crb
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cephfs-ctrlplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: cephfs-ctrlplugin-sa
+  namespace: rook-ceph
+---
+# ======================== CephFS ctrlplugin Role ========================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cephfs-ctrlplugin-r
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+# ===================== CephFS ctrlplugin RoleBinding ====================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cephfs-ctrlplugin-rb
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cephfs-ctrlplugin-r
+subjects:
+- kind: ServiceAccount
+  name: cephfs-ctrlplugin-sa
+  namespace: rook-ceph
+---
+# ====================== CephFS nodeplugin ClusterRole ===================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cephfs-nodeplugin-cr
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+---
+# =================== CephFS nodeplugin ClusterRoleBinding ===============
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cephfs-nodeplugin-crb
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cephfs-nodeplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: cephfs-nodeplugin-sa
+  namespace: rook-ceph
+---
+# ======================== CephFS nodeplugin Role ========================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cephfs-nodeplugin-r
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+# ===================== CephFS nodeplugin RoleBinding ====================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cephfs-nodeplugin-rb
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: manual-csi-rbac-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cephfs-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: cephfs-nodeplugin-sa
+  namespace: rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -27,6 +27,15 @@ spec:
       namespace: volsync-system
   values:
     csi:
+      # CRITICAL (Talos + Ceph tentacle v20+): the CephFS kernel client must pin
+      # ms_mode or the msgr2 handshake to the MDS fails ("mount error: no mds is
+      # up... or you may not be authorized") and NO cephfs volume can mount. RBD
+      # already pins the same via rbd_default_map_options. The rook 1.20 CSI
+      # migration to ceph-csi-operator dropped this from the live Driver CR once
+      # (2026-07) and broke every cephfs mount cluster-wide. Do NOT remove, and
+      # after any rook upgrade verify:
+      #   kubectl -n rook-ceph get driver rook-ceph.cephfs.csi.ceph.com \
+      #     -o jsonpath='{.spec.kernelMountOptions}'  # must be {"ms_mode":"prefer-crc"}
       cephFSKernelMountOptions: ms_mode=prefer-crc
       enableLiveness: true
       serviceMonitor:

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./csi-rbac.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Problem
The rook-ceph **v1.20.2** upgrade (ceph-csi-operator v1.0.4) left the CSI **controller plugins stuck at 0/2**:
```
FailedCreate: serviceaccount "rbd-ctrlplugin-sa" not found
```
The operator references per-driver ServiceAccounts (`rbd-ctrlplugin-sa`, `cephfs-ctrlplugin-sa`, `rbd-nodeplugin-sa`, `cephfs-nodeplugin-sa`) by name but neither it nor its subchart creates them. Result: **no volume provisioning, snapshots, clones, or volsync backups cluster-wide** (running apps kept working on cached SA tokens).

## Fix
Adds the 4 ServiceAccounts + their ClusterRoles / ClusterRoleBindings / Roles / RoleBindings, wired into the operator kustomization (`app/`) so Flux manages them.

- Rules copied **verbatim** from [ceph-csi-operator v1.0.4](https://github.com/ceph/ceph-csi-operator/tree/v1.0.4/deploy/charts/ceph-csi-drivers/templates), cross-checked against [rook v1.20.2 `csi-operator.yaml`](https://github.com/rook/rook/blob/v1.20.2/deploy/examples/csi-operator.yaml).
- Unprefixed SA names to match the operator's live `CSI_SERVICE_ACCOUNT_PREFIX=""`.
- `kubectl kustomize` builds clean; kubeconform-validated (20/20).

## Status
Already **applied live** to restore the cluster (CSI controllers now 5/5, nodeplugins 8/8, backups verified working). This PR persists it in git so it survives Flux prune / future reconciles.

## Follow-up
Root cause is the rook 1.20.2 / ceph-csi-operator v1.0.4 migration. Remove this file if a future chart version ships these SAs to avoid duplication.