### PR TITLE
fix(rook-ceph): raise mgr memory limit 2Gi -> 4Gi (OOMKilled)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -106,13 +106,16 @@ spec:
           requests:
             cpu: 250m
             memory: 2Gi
-        # The chart default of 1Gi was being exceeded once the insights /
-        # prometheus / dashboard modules + diskprediction warm up, causing
-        # both mgr-a and mgr-b to OOMKill (which fired the OomKilled critical
-        # alert). Bump headroom; mgr is a singleton workload anyway.
+        # mgr memory keeps outgrowing its limit (1Gi -> 2Gi -> now 4Gi). The
+        # insights / prometheus / dashboard modules warm up, and post-Ceph-
+        # tentacle (v20) the cephfs volumes/nfs connection pool grows under
+        # CSI/volsync subvolume clone load, spiking mgr-a to ~2Gi -> OOMKill.
+        # Bump headroom; mgr is a singleton (mgr-b standby). If it still OOMs
+        # at 4Gi, investigate the cephfs connection-pool leak / disable unused
+        # modules (e.g. nfs) rather than raising further.
         mgr:
           limits:
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 500m
             memory: 1Gi


### PR DESCRIPTION
Ceph `mgr-a` was **OOMKilled** hitting its 2Gi limit (peaked 1.93 GiB). Post-Ceph-tentacle (v20.2.2), the mgr's cephfs volumes/nfs connection pool grows under the CSI/volsync subvolume-clone load (backups now running again). This is a repeat of a prior bump (1Gi→2Gi didn't hold), so → **4Gi**.

mgr is a singleton (mgr-b is standby), so the OOM/failover is low-impact but fires the `OomKilled` critical alert. If it still OOMs at 4Gi, the next step is investigating the cephfs connection-pool growth / disabling unused mgr modules (e.g. nfs) rather than raising further.