### PR TITLE
feat(observability): Flux metrics fix + ExternalSecret not-ready alert

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/external-secrets.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/external-secrets.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-secrets-rules
+  labels:
+    prometheus: kube-prometheus-stack
+    role: alert-rules
+spec:
+  groups:
+    - name: external-secrets.rules
+      rules:
+        - alert: ExternalSecretNotReady
+          annotations:
+            summary: >-
+              ExternalSecret {{ $labels.exported_namespace }}/{{ $labels.name }}
+              has been failing to sync for more than 15 minutes.
+            description: >-
+              The ExternalSecret reports Ready=False — its target Kubernetes
+              Secret is stale or unpopulated (e.g. the referenced key is missing
+              from the backing store). Consumers reading that Secret may be
+              broken. Check `kubectl describe externalsecret -n
+              {{ $labels.exported_namespace }} {{ $labels.name }}` and the
+              secret store.
+            runbook_url: https://external-secrets.io/latest/introduction/troubleshooting/
+          expr: |
+            max by (exported_namespace, name) (
+              externalsecret_status_condition{condition="Ready", status="False"}
+            ) == 1
+          for: 15m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - ./flux.yaml
   - ./cert-manager.yaml
+  - ./external-secrets.yaml
   - ./node-and-storage.yaml
   - ./volsync.yaml

--- a/kubernetes/flux/config/kustomization.yaml
+++ b/kubernetes/flux/config/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - ./flux.yaml
   - ./cluster.yaml
+  # PodMonitor for the Flux controllers — without this, gotk_* metrics are not
+  # scraped and the FluxReconciliation* alerts (kube-prometheus-stack) never fire.
+  - ./podmonitors.yaml


### PR DESCRIPTION
Two of today's failure classes had monitoring that *should* have fired but didn't.

**Flux:** the controller `PodMonitor` and `FluxReconciliation{Failure,Stalled}` / `FluxSuspended` alerts already existed, but `podmonitors.yaml` was never referenced in `kubernetes/flux/config/kustomization.yaml` — so `gotk_*` metrics were never scraped and the alerts could never fire. Wired it in. This would have immediately flagged the stuck rook/cilium HelmReleases.

**ExternalSecret:** added `ExternalSecretNotReady` (metrics already scraped). Fires when an ExternalSecret is `Ready=False` >15m — would have caught the `alertmanager`/`gatus` Pushover-secret sync failures instead of silently leaving stale Secrets.