### PR TITLE
feat(observability): Flux gotk_resource_info via kube-state-metrics

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -254,6 +254,101 @@ spec:
               replacement: $1
               sourceLabels: ["__meta_kubernetes_pod_node_name"]
               targetLabel: kubernetes_node
+      # Emit gotk_resource_info{ready,suspended,stalled,...} for Flux CRs.
+      # Flux controllers dropped gotk_reconcile_condition in v2.2, so the
+      # FluxReconciliation* alerts depend on this. Do NOT add
+      # --custom-resource-state-only / collectors:[] — that drops all core
+      # kube_* metrics on this shared stack.
+      rbac:
+        extraRules:
+          - apiGroups:
+              - kustomize.toolkit.fluxcd.io
+              - helm.toolkit.fluxcd.io
+              - source.toolkit.fluxcd.io
+            resources:
+              - kustomizations
+              - helmreleases
+              - gitrepositories
+              - ocirepositories
+              - helmrepositories
+              - helmcharts
+              - buckets
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                metricNamePrefix: gotk
+                metrics:
+                  - name: resource_info
+                    help: The current state of a Flux Kustomization resource.
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      stalled: [status, conditions, "[type=Stalled]", status]
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  version: v2
+                  kind: HelmRelease
+                metricNamePrefix: gotk
+                metrics:
+                  - name: resource_info
+                    help: The current state of a Flux HelmRelease resource.
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      stalled: [status, conditions, "[type=Stalled]", status]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: GitRepository
+                metricNamePrefix: gotk
+                metrics:
+                  - name: resource_info
+                    help: The current state of a Flux GitRepository resource.
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: OCIRepository
+                metricNamePrefix: gotk
+                metrics:
+                  - name: resource_info
+                    help: The current state of a Flux OCIRepository resource.
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
     kubeApiServer:
       enabled: true
     kubeControllerManager:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/flux.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/flux.yaml
@@ -11,20 +11,23 @@ spec:
   groups:
     - name: flux.rules
       rules:
+        # Uses gotk_resource_info (emitted by kube-state-metrics
+        # CustomResourceState — see the kube-prometheus-stack HelmRelease).
+        # Flux controllers dropped gotk_reconcile_condition in v2.2.
         - alert: FluxReconciliationFailure
           annotations:
             summary: >-
-              Flux {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }}
+              Flux {{ $labels.customresource_kind }}
+              {{ $labels.exported_namespace }}/{{ $labels.name }}
               has been failing to reconcile for more than 15 minutes.
             description: >-
-              The Flux resource {{ $labels.kind }}/{{ $labels.name }} in
-              namespace {{ $labels.namespace }} reports Ready=False.
-              Check `flux get {{ $labels.kind | toLower }}s -A` and the
-              controller logs for the cause.
+              The Flux resource reports Ready=False (and is not suspended).
+              Check `flux get {{ $labels.customresource_kind | toLower }}s -A`
+              and the controller logs for the cause.
             runbook_url: https://fluxcd.io/flux/cheatsheets/troubleshooting/
           expr: |
-            max by (namespace, name, kind) (
-              gotk_reconcile_condition{type="Ready", status="False"}
+            max by (exported_namespace, name, customresource_kind) (
+              gotk_resource_info{ready="False", suspended="false"}
             ) == 1
           for: 15m
           labels:
@@ -33,16 +36,17 @@ spec:
         - alert: FluxReconciliationStalled
           annotations:
             summary: >-
-              Flux {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }}
+              Flux {{ $labels.customresource_kind }}
+              {{ $labels.exported_namespace }}/{{ $labels.name }}
               has been stalled for more than 30 minutes.
             description: >-
               Stalled reconciliations require manual intervention; Flux will
-              not retry without a spec change. Inspect status conditions on
-              the resource.
+              not retry without a spec change. Inspect the resource's status
+              conditions.
             runbook_url: https://fluxcd.io/flux/cheatsheets/troubleshooting/
           expr: |
-            max by (namespace, name, kind) (
-              gotk_reconcile_condition{type="Stalled", status="True"}
+            max by (exported_namespace, name, customresource_kind) (
+              gotk_resource_info{stalled="True"}
             ) == 1
           for: 30m
           labels:
@@ -51,15 +55,16 @@ spec:
         - alert: FluxSuspended
           annotations:
             summary: >-
-              Flux {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }}
+              Flux {{ $labels.customresource_kind }}
+              {{ $labels.exported_namespace }}/{{ $labels.name }}
               has been suspended for more than 1 hour.
             description: >-
               A suspended resource will not reconcile. Confirm this is
               intentional; if not, run
-              `flux resume {{ $labels.kind | toLower }} -n {{ $labels.namespace }} {{ $labels.name }}`.
+              `flux resume {{ $labels.customresource_kind | toLower }} -n {{ $labels.exported_namespace }} {{ $labels.name }}`.
           expr: |
-            max by (namespace, name, kind) (
-              gotk_suspend_status
+            max by (exported_namespace, name, customresource_kind) (
+              gotk_resource_info{suspended="true"}
             ) == 1
           for: 1h
           labels:


### PR DESCRIPTION
Completes the Flux alerting (follow-up to #1134). The Flux controllers dropped `gotk_reconcile_condition` in v2.2, so the `FluxReconciliation*` alerts had no backing metric — the podmonitor only yields reconcile-duration/event metrics.

- Configures **kube-state-metrics CustomResourceState** to emit `gotk_resource_info{ready,suspended,stalled,customresource_kind,...}` for Kustomization / HelmRelease / GitRepository / OCIRepository, plus the RBAC for KSM to list/watch those CRDs.
- Rewrites `flux.yaml` to alert on `gotk_resource_info{ready="False",suspended="false"}` (15m), `stalled="True"`, and `suspended="true"`.
- **Does NOT** set `--custom-resource-state-only`/`collectors:[]` — so all core `kube_*` metrics are retained on this shared stack.

Result: a stuck HelmRelease/Kustomization (like today's rook/cilium) now pages within 15m. Sourced from fluxcd/flux2-monitoring-example.