### PR TITLE
feat(gatus): synthetic end-to-end checks for user-facing apps

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -249,3 +249,120 @@ endpoints:
       - "[RESPONSE_TIME] < 5000"
     alerts:
       - type: pushover
+
+  # Synthetic end-to-end checks of user-facing apps via their real ingress
+  # URLs (ingress -> app). Catches "pod is Ready but the app is unreachable"
+  # (e.g. HA loading over HTTP but its runtime broken) — which pod/HelmRelease
+  # health alone does not detect. any(200,302,401) = app is serving (auth-gated
+  # apps redirect/challenge); a 5xx/timeout/conn-refused fails the check.
+  - name: home-assistant
+    group: applications
+    url: https://hass.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: frigate
+    group: applications
+    url: https://frigate.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: paperless
+    group: applications
+    url: https://paperless.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: mealie
+    group: applications
+    url: https://mealie.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: homebox
+    group: applications
+    url: https://homebox.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: komga
+    group: applications
+    url: https://komga.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: radarr
+    group: applications
+    url: https://radarr.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover
+
+  - name: sonarr
+    group: applications
+    url: https://sonarr.${SECRET_DOMAIN}
+    interval: 2m
+    client:
+      dns-resolver: tcp://192.168.5.2:53
+      insecure: true
+      timeout: 10s
+    conditions:
+      - "[STATUS] == any(200, 302, 401)"
+      - "[RESPONSE_TIME] < 5000"
+    alerts:
+      - type: pushover


### PR DESCRIPTION
## What
Adds an `applications` group to the Gatus config that probes the real ingress
URLs of the main user-facing apps:

- home-assistant (`hass`), frigate, paperless, mealie, homebox (default ns)
- komga, radarr, sonarr (media ns)

Each check: HTTPS via internal DNS (`192.168.5.2:53`), `insecure: true`,
`timeout: 10s`, conditions `[STATUS] == any(200, 302, 401)` and
`[RESPONSE_TIME] < 5000`, Pushover alert.

## Why
This is monitor #3 of 3 from the "can we have tests/monitors for this class of
issue?" thread. It closes the gap the recent **Home Assistant** outage exposed:
the pod was `Ready` and the HelmRelease healthy, yet the app was unreachable
through its ingress. Pod/HelmRelease health alone can't catch that — a real
end-to-end HTTP probe can.

`any(200, 302, 401)` = the app is serving (auth-gated apps redirect or
challenge); a `5xx`, timeout, or connection-refused fails the check after the
existing 3-sample failure threshold.

## Validation
- `python3` YAML multi-doc parse: OK
- `kubectl kustomize kubernetes/apps/observability/gatus/app`: OK
- All 8 hostnames verified against the repo's actual HTTPRoute hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)