### PR TITLE
feat(observability): x509-certificate-exporter for non-cert-manager cert expiry

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - ./smartctl-exporter/ks.yaml
   - ./snmp-exporter/ks.yaml
   - ./unpoller/ks.yaml
+  - ./x509-certificate-exporter/ks.yaml

--- a/kubernetes/apps/observability/x509-certificate-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/x509-certificate-exporter/app/helmrelease.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app x509-certificate-exporter
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: x509-certificate-exporter
+      version: 4.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: enix
+        namespace: flux-system
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+  values:
+    fullnameOverride: *app
+    # Scan in-cluster TLS Secrets for expiring certificates. This covers
+    # certs that cert-manager does NOT own (and thus that
+    # certmanager_certificate_expiration_timestamp_seconds misses) — e.g. the
+    # Cilium/Hubble self-signed mTLS certs, webhook CA bundles, and any other
+    # kubernetes.io/tls Secret. cert-manager Certificates are already alerted
+    # on separately via the cert-manager PrometheusRules.
+    secretsExporter:
+      enabled: true
+      # Default watches kubernetes.io/tls Secrets' tls.crt across all namespaces.
+      secretTypes:
+        - type: kubernetes.io/tls
+          key: tls.crt
+      resources:
+        requests:
+          cpu: 20m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
+    # Only the Secrets exporter is needed; node-filesystem (kubelet/etcd) certs
+    # are managed by Talos and would require hostPath mounts Talos restricts.
+    hostPathsExporter:
+      daemonSets: {}
+    service:
+      create: true
+    # kube-prometheus-stack selectors are empty ({}), so the chart's own
+    # ServiceMonitor and PrometheusRule are picked up without extra labels.
+    prometheusServiceMonitor:
+      create: true
+    prometheusRules:
+      create: true
+      # Warn well before expiry, critical when renewal is genuinely overdue.
+      warningDaysLeft: 21
+      criticalDaysLeft: 7
+      # Alert if the exporter itself can't read Secrets / reach the API —
+      # otherwise a monitoring regression would go silent.
+      alertOnReadErrors: true
+      readErrorsSeverity: warning
+      certificateRenewalsSeverity: warning
+      certificateExpirationsSeverity: critical
+  driftDetection:
+    mode: enabled

--- a/kubernetes/apps/observability/x509-certificate-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/x509-certificate-exporter/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/x509-certificate-exporter/ks.yaml
+++ b/kubernetes/apps/observability/x509-certificate-exporter/ks.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app x509-certificate-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/observability/x509-certificate-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/flux/repositories/helm/enix.yaml
+++ b/kubernetes/flux/repositories/helm/enix.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: enix
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.enix.io

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./coredns.yaml
   - ./descheduler.yaml
   - ./emqx.yaml
+  - ./enix.yaml
   - ./external-dns.yaml
   - ./external-secrets.yaml
   - ./grafana.yaml


### PR DESCRIPTION
## What
Deploys [`enix/x509-certificate-exporter`](https://github.com/enix/x509-certificate-exporter)
(v4.1.0, secrets-scanning Deployment) into `observability`. It watches every
`kubernetes.io/tls` Secret cluster-wide and exposes:
- `x509_cert_not_after` — expiry timestamp per cert
- `x509_cert_expired` — already-expired flag
- `x509_read_errors` — exporter can't read a Secret / reach the API

Also adds the `enix` HelmRepository.

## Why
This is monitor #2 of the 3 requested. `certmanager_certificate_expiration_timestamp_seconds`
(used by the existing cert-manager PrometheusRules) **only covers cert-manager
`Certificate` resources.** Certs that live in plain TLS Secrets cert-manager
doesn't own are invisible to it — most importantly the **Cilium/Hubble
self-signed mTLS certs**, whose expiry caused a real outage this incident, plus
webhook CA bundles and any hand-rolled TLS Secret. This exporter covers all of
them.

## Alerting
The chart ships its own `ServiceMonitor` + `PrometheusRule`. The cluster's
Prometheus `ruleSelector`/`serviceMonitorSelector` are empty `{}`, so both are
selected without extra labels. Rules:
- `CertificateRenewal` — warning, < 21 days left
- `CertificateExpiration` — critical, < 7 days left
- `X509ExporterReadErrors` — warning (guards against a silent monitoring regression)

Scope note: only the Secrets exporter is enabled. Node-filesystem (kubelet/etcd)
certs are Talos-managed and would need hostPath mounts Talos restricts.

## Validation
- `kubectl kustomize` of the app dir and `flux/repositories/helm`: OK
- chart `x509-certificate-exporter` v4.1.0 confirmed present in `https://charts.enix.io`
- Prometheus selectors verified empty (rules will be loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)