### PR TITLE
fix(flux): raise Helm timeout to 15m for slow-rollout HelmReleases (bazarr, litellm)

### DIFF
--- a/kubernetes/apps/default/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/default/litellm/app/helmrelease.yaml
@@ -4,6 +4,10 @@ metadata:
   name: &app litellm
 spec:
   interval: 30m
+  # litellm's readiness (/health/readiness) cold-start loads all configured
+  # model endpoints + checks the DB, taking ~5m — right at Helm's default 5m
+  # wait, so upgrades raced the timeout and rolled back in a loop. Give headroom.
+  timeout: 15m
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -6,6 +6,10 @@ metadata:
   name: &app bazarr
 spec:
   interval: 30m
+  # Recreate strategy + RWO Ceph RBD volume handoff + multi-container init
+  # (init-db, subcleaner) push the rollout past Helm's default 5m wait, so
+  # every upgrade timed out and rolled back in a loop. Give it real headroom.
+  timeout: 15m
   chart:
     spec:
       chart: app-template


### PR DESCRIPTION
## Problem
The new `FluxReconciliationStalled` alert surfaced a chronic, pre-existing
issue: `bazarr` and `litellm` have been stuck in an
upgrade→timeout→rollback loop for a long time (Helm release revisions at
**v44** and **v62** respectively). helm-controller logs show each `upgrade`
action running the **full 5m0s** default timeout, then "release is in a failed
state" → rollback → "exceeded maximum retries".

The **apps themselves are healthy** — the pods reach Ready, just *after* Helm
gives up waiting (rollback is a no-op since git-desired and prior manifests are
identical). So the apps ran fine while Flux churned failed revisions and never
reported Ready.

## Root cause
Rollout time exceeds Helm's default 5m `--wait`:
- **bazarr** — `Recreate` strategy + RWO Ceph RBD volume detach/reattach +
  multi-container init (`init-db`, `subcleaner`) regularly exceeds 5m.
- **litellm** — no volume, but `/health/readiness` cold-start (loads all
  configured model endpoints + DB check) takes ~5m, racing the timeout (caught
  Ready at 4m42s on one attempt — just under).

`reloader` and `progressDeadlineSeconds=600` are identical on all three
app-template apps; `qbittorrent` just happened to finish under 5m once and
stuck, which is why only these two kept failing.

## Fix
Set `spec.timeout: 15m` on both HelmReleases so Helm's wait accommodates the
real rollout time and the release converges to Ready.

## Validation
- `kubectl kustomize` of both app dirs: OK
- Root cause confirmed from helm-controller logs (5m0s upgrade → failed → rollback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)