### PR TITLE
fix(litellm): raise memory limit to 2Gi (OOMKilled on startup)

### DIFF
--- a/kubernetes/apps/default/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/default/litellm/app/helmrelease.yaml
@@ -4,10 +4,6 @@ metadata:
   name: &app litellm
 spec:
   interval: 30m
-  # litellm's readiness (/health/readiness) cold-start loads all configured
-  # model endpoints + checks the DB, taking ~5m — right at Helm's default 5m
-  # wait, so upgrades raced the timeout and rolled back in a loop. Give headroom.
-  timeout: 15m
   chart:
     spec:
       chart: app-template
@@ -44,9 +40,12 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 512Mi
-              limits:
+                # The main-stable image (bumped to a1745e6 in 890c9dfb) OOMKills
+                # on startup at the old 1Gi limit (exit 137), so every upgrade
+                # crashlooped and rolled back to the previous image. Raised.
                 memory: 1Gi
+              limits:
+                memory: 2Gi
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
## Root cause
`litellm` was stuck in a Helm upgrade→fail→rollback loop (release at **v67**).
The desired pod's `app` container is **OOMKilled on startup** (exit code 137,
`reason: OOMKilled`) at its `1Gi` limit — it crashloops before it can pass
`/health/readiness`, so Helm never sees it Ready, times out, and rolls back to
the *previous* image (which fit in 1Gi and ran fine — that's the "healthy" pod
that was visible during earlier debugging).

The trigger is the recent image bump `ghcr.io/berriai/litellm` → `a1745e6`
(commit `890c9dfb`); the newer image's startup footprint exceeds 1Gi.

## Fix
- `limits.memory` 1Gi → **2Gi**, `requests.memory` 512Mi → **1Gi**.
- Also removes the `timeout: 15m` added to litellm in the prior commit — that
  was based on a wrong (slow-readiness) diagnosis; the real cause is OOM, and
  once it stops OOMing the rollout finishes well within the default 5m. bazarr
  keeps its 15m (its Recreate + RWO Ceph volume handoff genuinely can exceed 5m).

## How it was found
`FluxReconciliationStalled` (the alert added earlier this session) flagged the
release; helm-controller logs + the pod's `lastState.terminated` (exit 137 /
OOMKilled) pinned the cause.

## Validation
- `kubectl kustomize` of the litellm app dir: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)