### PR TITLE
fix(bazarr): add startup probe (1.6.0 boots slower than liveness allows)

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -65,6 +65,21 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+              # bazarr 1.6.0 (Python 3.14) takes >30s to start serving /health,
+              # so the liveness probe (0s delay + 3x10s) was SIGTERM-killing it
+              # mid-boot in a crashloop. A startup probe holds liveness/readiness
+              # off until /health responds, allowing up to ~5m to come up.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 30
             securityContext: &securityContext
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Root cause
`bazarr` was stuck in an upgrade→crashloop→rollback loop after the **v1.6.0**
bump (#1108). The v1.6.0 image runs Python 3.14 and takes **>30s** to start
serving `/health`. Its liveness probe (`initialDelaySeconds: 0` +
`failureThreshold: 3` × `periodSeconds: 10` ≈ 30s) SIGTERM-killed the `app`
container mid-boot (exit 143), crashlooping — so the Helm upgrade never went
Ready and rolled back to 1.5.6.

## Fix (fix-forward)
Add a `startup` probe (`/health`, up to ~5m: `failureThreshold: 30` ×
`periodSeconds: 10`). Kubernetes holds liveness/readiness until the startup
probe first succeeds, so bazarr gets time to boot instead of being killed.

## How it was found
`FluxReconciliationStalled` flagged the release; the `app` container's
`lastState` (exit 143 at ~29s) + logs (`Scheduler will use...`, then killed
mid-startup) pinned it to a probe-timing kill, not an app crash.

## Validation
- `kubectl kustomize` of the bazarr app dir: OK
- Will verify the pod passes startup and the release goes Ready after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)