### PR TITLE
fix(rook-ceph): trim optional mgr modules to curb active-mgr OOM

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -79,11 +79,23 @@ spec:
       mgr:
         modules:
           - enabled: true
-            name: insights
-          - enabled: true
             name: pg_autoscaler
           - enabled: true
             name: rook
+          # Trim optional mgr modules to reduce active-mgr memory pressure after
+          # the Ceph tentacle 20.2.2 upgrade started OOMKilling the active mgr
+          # (grows to the 4Gi limit in ~14h). The prometheus module (usual leak
+          # culprit) is already patched in 20.2.2 and tuned (exclude_perf_counters
+          # true, rbd_stats_pools empty), so trim the other enabled-but-unused
+          # modules: insights (chatty health_history writer), nfs (no exports /
+          # CephNFS CRs), restful (legacy REST API, has its own historical leak).
+          # See rook/rook#17786 (matching mgr OOM on rook 1.20 + ceph 20.2.2).
+          - enabled: false
+            name: insights
+          - enabled: false
+            name: nfs
+          - enabled: false
+            name: restful
       network:
         connections:
           requireMsgr2: true


### PR DESCRIPTION
## Context
Since the Ceph **Tentacle 20.2.2** / rook **1.20.2** upgrade, the *active*
ceph-mgr grows unbounded to its 4Gi limit in ~14h and gets **OOMKilled**
(~once every 14h). Each OOM/failover window intermittently stalls CSI RBD/CephFS
snapshot+clone provisioning, which fails volsync mover jobs (`KubeJobFailed`,
stale-backup canary).

## Why not the usual prometheus-module fix
The well-known mgr leak (tracker [#68989](https://tracker.ceph.com/issues/68989))
is **already patched in 20.2.2** ([PR #66482](https://github.com/ceph/ceph/pull/66482))
and the module is already optimally configured here: `exclude_perf_counters=true`,
`rbd_stats_pools` empty (no per-image stats), `cache=true`, and `ceph-exporter`
handles perf counters. `/metrics` is only ~1376 lines. So prometheus isn't the cause.

The active mgr ran fine at 1–2Gi for ~18 months (limit set since Dec 2024); the
growth rate is new with this upgrade, matching the open upstream report
[rook/rook#17786](https://github.com/rook/rook/issues/17786) (mgr OOM on rook 1.20 + ceph 20.2.2).

## Change
Trim optional, enabled-but-unused mgr modules to lower baseline memory and rule
out a secondary leak:
- **insights** — chatty `health_history` writer we explicitly enabled; not needed.
- **nfs** — enabled but unused (0 exports, no CephNFS CRs).
- **restful** — legacy REST API, unused, has its own historical leak.

Keeps `pg_autoscaler` + `rook`. The 4Gi limit stays as a safety net.

## Follow-up (not in this PR)
- `ceph mgr fail` to reset the leaked active mgr and get a clean baseline.
- Measure active-mgr RSS slope over a full >14h cycle to confirm it flattens.
- Track rook/rook#17786 for the upstream fix; bump to the next 20.2.x patch when it lands.

## Validation
- `kubectl kustomize` of the cluster dir: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)