### PR TITLE
fix(volsync-canary): escape ${identity} so Flux substitution stops eating it

### DIFF
--- a/kubernetes/apps/volsync-system/volsync-canary/app/cronjob.yaml
+++ b/kubernetes/apps/volsync-system/volsync-canary/app/cronjob.yaml
@@ -158,8 +158,13 @@ data:
       #   `  2026-05-03 19:00:25 UTC k0495... 1.6 GB ...`           (a snapshot)
       #   `  + 9 identical snapshots until 2026-05-03 18:00:24 UTC` (a span)
       # The most recent snapshot in the block is the LAST date of either kind.
+      # NOTE: $${identity} (not ${identity}) — Flux postBuild var substitution
+      # (substituteFrom in kubernetes/flux/apps.yaml) rewrites ${...} tokens in
+      # this ConfigMap; an undefined ${identity} was being replaced with "" so
+      # the awk matched ":/data" and every identity reported "no snapshots".
+      # $$ escapes to a literal $ so the shell sees ${identity} at runtime.
       latest=$(printf '%s\n' "$ALL" \
-        | awk -v id="${identity}:/data" '
+        | awk -v id="$${identity}:/data" '
             $0 == id { in_block=1; next }
             in_block && /^[a-zA-Z]/ { in_block=0 }
             in_block && /^  [0-9]{4}-[0-9]{2}-[0-9]{2} / { last=$1 " " $2 " " $3 }


### PR DESCRIPTION
## Symptom
`KubeJobFailed` for `volsync-canary` — the daily canary reported **"no snapshots
in repo" for all 10 identities**, implying total backup loss. But backups are
healthy: ReplicationSources are syncing and `kopia-maint` runs fine every 4h.

## Root cause (Flux postBuild substitution ate a shell variable)
The canary.sh awk matches each identity's snapshot block with the shell var
`${identity}`:
```sh
awk -v id="${identity}:/data" ...
```
`kubernetes/flux/apps.yaml` applies `postBuild.substituteFrom` to **every** app
Kustomization, so Flux runs envsubst over this ConfigMap's contents. `${identity}`
is not a defined Flux substitution variable, so Flux replaced it with an **empty
string**. The deployed script became:
```sh
awk -v id=":/data" ...
```
which never matches Kopia's `<identity>:/data` block headers → zero snapshots
found → every identity fails. (The `kopia repository connect` kept working
because those creds use the **unbraced** `$AWS_S3_ENDPOINT` / `$KOPIA_PASSWORD`
form, which the substitution left alone — only braced `${...}` is affected.)

This was invisible in git review because `kubectl kustomize` / `git show` show
the correct `${identity}`; the corruption only happens at Flux apply time. I
confirmed the live ConfigMap contained `:/data`.

## Fix
Escape the shell var as `$${identity}`. Flux renders `$$` → `$`, so the applied
ConfigMap gets literal `${identity}` and the shell expands it correctly at runtime.

## Validation
- `kubectl kustomize` build now emits `$${identity}` (→ `${identity}` post-Flux)
- Verified live ConfigMap had the corrupted `:/data`; this restores per-identity matching
- After merge/reconcile I'll re-run the canary to confirm it reports fresh snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)