### PR TITLE
fix(volsync-canary): use unbraced $identity (prev $${identity} broke envsubst)

### DIFF
--- a/kubernetes/apps/volsync-system/volsync-canary/app/cronjob.yaml
+++ b/kubernetes/apps/volsync-system/volsync-canary/app/cronjob.yaml
@@ -158,13 +158,15 @@ data:
       #   `  2026-05-03 19:00:25 UTC k0495... 1.6 GB ...`           (a snapshot)
       #   `  + 9 identical snapshots until 2026-05-03 18:00:24 UTC` (a span)
       # The most recent snapshot in the block is the LAST date of either kind.
-      # NOTE: $${identity} (not ${identity}) — Flux postBuild var substitution
-      # (substituteFrom in kubernetes/flux/apps.yaml) rewrites ${...} tokens in
-      # this ConfigMap; an undefined ${identity} was being replaced with "" so
-      # the awk matched ":/data" and every identity reported "no snapshots".
-      # $$ escapes to a literal $ so the shell sees ${identity} at runtime.
+      # NOTE: unbraced $identity (not ${identity}). Flux postBuild var
+      # substitution (substituteFrom in kubernetes/flux/apps.yaml) rewrites only
+      # BRACED ${...} tokens in this ConfigMap; an undefined ${identity} was
+      # replaced with "" so the awk matched ":/data" and every identity reported
+      # "no snapshots". Unbraced $identity is left alone by Flux (same reason the
+      # $AWS_* env vars below survive) and the shell still expands it ($ stops at
+      # the ':'). Do NOT use $${identity} — drone/envsubst fails to parse it.
       latest=$(printf '%s\n' "$ALL" \
-        | awk -v id="$${identity}:/data" '
+        | awk -v id="$identity:/data" '
             $0 == id { in_block=1; next }
             in_block && /^[a-zA-Z]/ { in_block=0 }
             in_block && /^  [0-9]{4}-[0-9]{2}-[0-9]{2} / { last=$1 " " $2 " " $3 }


### PR DESCRIPTION
Follow-up to #1145, which was wrong.

#1145 tried to protect the awk var by escaping it as `$${identity}`. But Flux's
`drone/envsubst` can't parse `$${...}` — it threw `envsubst error: variable
substitution failed: unable to parse variable name`, which made the **entire**
volsync-canary Kustomization fail to apply. It got stuck at the old revision,
still serving the corrupted `:/data` script, so the canary kept failing.

## Correct fix
Flux postBuild substitution only rewrites **braced** `${VAR}`. The right fix is
therefore the **unbraced** `$identity`:
- Flux leaves unbraced `$identity` alone (the same reason the `$AWS_S3_ENDPOINT`
  / `$KOPIA_PASSWORD` env vars in this script were never corrupted).
- The shell still expands `$identity` correctly — `:` terminates the variable
  name, so `"$identity:/data"` → `<identity>:/data`.
- No `$$`, so no envsubst parse error.

This matches the unbraced `$var` style used throughout the rest of canary.sh.

## Validation
- `kubectl kustomize` build emits `awk -v id="$identity:/data"` and builds clean
- After merge/reconcile I'll confirm the Kustomization goes Ready, the live
  ConfigMap contains `$identity`, and the canary reports fresh snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)