### PR TITLE
fix(bazarr): shorten & harden the ~3min flaky boot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -132,6 +132,23 @@
       ],
     },
     {
+      description: [
+        // bazarr 1.6.0 ships on Python 3.14, which upstream explicitly flags
+        // as unsupported ("you're on your own"). Downgrading is unsafe (1.6.0
+        // migrated the shared Postgres schema), so hold here and review each
+        // bump by hand until home-operations/upstream moves back to <=3.13.
+        'bazarr: manual approval (unsupported Python 3.14 image)',
+      ],
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        '/home-operations/bazarr/',
+      ],
+      automerge: false,
+      dependencyDashboardApproval: true,
+    },
+    {
       matchDatasources: [
         'helm',
       ],

--- a/kubernetes/apps/media/bazarr/app/gatus.yaml
+++ b/kubernetes/apps/media/bazarr/app/gatus.yaml
@@ -10,7 +10,9 @@ data:
     endpoints:
       - name: bazarr
         group: guarded
-        url: http://bazarr.media.svc.cluster.local:6767/
+        # /health is a cheap 200; / renders the SPA and can blip the 5s
+        # response-time threshold while bazarr is busy indexing subtitles.
+        url: http://bazarr.media.svc.cluster.local:6767/health
         interval: 1m
         ui:
           hide-hostname: true

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -62,7 +62,10 @@ spec:
                     port: &port 6767
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  # waitress is single-threaded WSGI; during disk indexing a 1s
+                  # timeout (3 fails = 30s) can liveness-kill a busy-but-alive
+                  # bazarr and cause a needless ~3min-boot restart.
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
               # bazarr 1.6.0 (Python 3.14) takes >30s to start serving /health,
@@ -78,7 +81,7 @@ spec:
                     port: *port
                   initialDelaySeconds: 5
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 30
             securityContext: &securityContext
               allowPrivilegeEscalation: false
@@ -86,7 +89,10 @@ spec:
               capabilities: {drop: ["ALL"]}
             resources:
               requests:
-                cpu: 10m
+                # 10m starved the CPU-heavy Python init under node CPU
+                # contention, stretching boot to ~2m40s (silent gap before
+                # waitress binds :6767). A real floor keeps boot time bounded.
+                cpu: 200m
               limits:
                 memory: 1Gi
           exportarr:


### PR DESCRIPTION
## Why

bazarr's "flakiness" is that **every restart is a ~3 min hard outage**. Boot log shows a silent 2m41s gap before waitress binds `:6767`:

```
17:43:51  Plex OAuth cache cleanup started
   ⟵ 2m41s silence ⟶
17:46:32  BAZARR is started and waiting for requests
```

That block (Plex OAuth cleanup + subtitle-provider load + DB work, on **unsupported Python 3.14**) is CPU-heavy, and the app container requested only `cpu: 10m` — so on the CPU-overcommitted node (116% limits) it gets starved → variable, slow boots → Gatus (60s poll on `/`) flags it down → Pushover. Until #1143 the liveness probe was also SIGTERM-killing it mid-boot; the startup probe fixed the crashloop but each restart is still a full ~3 min outage.

## Changes

- **CPU floor** — `app` request `10m → 200m`, giving the init a real scheduling weight (steady-state use is ~3m, so this is a boot burst reservation, not a limit).
- **Probe timeouts** — liveness/readiness/startup `timeoutSeconds: 1 → 5`; single-threaded waitress can miss a 1s deadline while indexing and get needlessly liveness-killed.
- **Gatus** — poll `/health` (cheap 200) instead of `/` (renders the SPA, can blip the 5s threshold under load).
- **Renovate** — `home-operations/bazarr` now requires manual dashboard approval, documenting the Python 3.14 fragility. **No image downgrade**: 1.6.0 migrated the shared Postgres schema, so reverting to 1.5.6 (last 3.13 build) is unsafe.

## Notes

- Merging triggers one rolling restart (~3 min, expected).
- Not addressed here: disabling Plex (runtime UI toggle) — Plex is the primary player, kept on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)