### PR TITLE
fix(volsync): auto-clean bootstrap temp/cache PVCs after restore

### DIFF
--- a/kubernetes/templates/volsync/minio.yaml
+++ b/kubernetes/templates/volsync/minio.yaml
@@ -40,6 +40,12 @@ spec:
     accessModes: ["${VOLSYNC_SNAP_ACCESSMODES:-ReadWriteOnce}"]
     capacity: ${VOLSYNC_CAPACITY:-2Gi}
     copyMethod: Snapshot
+    # One-time restore: drop the temp dest + cache PVCs once the snapshot is
+    # taken, otherwise every app leaves a volsync-<app>-bootstrap-dest PVC
+    # bound forever. (Not set on the ReplicationSource — its cache is reused
+    # across scheduled backups.)
+    cleanupCachePVC: true
+    cleanupTempPVC: true
     moverResources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Why

The bootstrap \`ReplicationDestination\` in the shared VolSync template uses \`copyMethod: Snapshot\` but never set the cleanup flags, so every app's **one-time** bootstrap restore leaves a \`volsync-<app>-bootstrap-dest\` PVC bound **forever**. ~10 had accumulated (~60Gi) across frigate, home-assistant, homebox, karakeep, mealie, paperless, unifi, zigbee2mqtt, bazarr, qbittorrent — some 249 days old.

There is no Kyverno or cleanup job to catch them, so they just pile up.

## Change

Add \`cleanupTempPVC: true\` + \`cleanupCachePVC: true\` to the bootstrap RD. VolSync then drops the temp dest + cache PVCs once the restore snapshot is taken. Safe: the app PVC clones from the snapshot (\`latestImage\`), not the temp PVC.

**Only** on the bootstrap RD — deliberately **not** on the \`ReplicationSource\`, whose cache is reused across scheduled backups (cleaning it every run would force a full re-cache each time).

## Scope

- Prevents **future** buildup (applies to every app's bootstrap going forward; no trigger change, so no immediate reconcile churn).
- The ~10 **existing** lingering \`-bootstrap-dest\` PVCs are cleaned up manually out-of-band (they won't re-clean automatically since their manual trigger already fired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)