### PR TITLE
feat(talos): NUT upsmon secondary + Talos v1.13.8 bump (#1124)

### DIFF
--- a/kubernetes/apps/system-upgrade/plans/01-talos-workers-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/plans/01-talos-workers-upgrade.yaml
@@ -6,7 +6,7 @@ metadata:
   name: talos-workers
   namespace: system-upgrade
 spec:
-  version: v1.13.7
+  version: v1.13.8
   serviceAccountName: system-upgrade
   concurrency: 1
   exclusive: true
@@ -18,7 +18,7 @@ spec:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
   upgrade:
-    image: ghcr.io/siderolabs/installer:v1.13.7
+    image: ghcr.io/siderolabs/installer:v1.13.8
   drain:
     force: true
     disableEviction: true

--- a/kubernetes/apps/system-upgrade/plans/01-talos-workers-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/plans/01-talos-workers-upgrade.yaml
@@ -6,7 +6,7 @@ metadata:
   name: talos-workers
   namespace: system-upgrade
 spec:
-  version: v1.13.0
+  version: v1.13.7
   serviceAccountName: system-upgrade
   concurrency: 1
   exclusive: true
@@ -18,7 +18,7 @@ spec:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
   upgrade:
-    image: ghcr.io/siderolabs/installer:v1.13.0
+    image: ghcr.io/siderolabs/installer:v1.13.7
   drain:
     force: true
     disableEviction: true

--- a/kubernetes/apps/system-upgrade/plans/02-talos-controlplane-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/plans/02-talos-controlplane-upgrade.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: system-upgrade
 spec:
   # Wait for worker Plan to complete before starting
-  version: v1.13.7
+  version: v1.13.8
   serviceAccountName: system-upgrade
   concurrency: 1
   exclusive: true
@@ -18,7 +18,7 @@ spec:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
   upgrade:
-    image: ghcr.io/siderolabs/installer:v1.13.7
+    image: ghcr.io/siderolabs/installer:v1.13.8
   drain:
     force: false
     disableEviction: false

--- a/kubernetes/apps/system-upgrade/plans/02-talos-controlplane-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/plans/02-talos-controlplane-upgrade.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: system-upgrade
 spec:
   # Wait for worker Plan to complete before starting
-  version: v1.13.0
+  version: v1.13.7
   serviceAccountName: system-upgrade
   concurrency: 1
   exclusive: true
@@ -18,7 +18,7 @@ spec:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
   upgrade:
-    image: ghcr.io/siderolabs/installer:v1.13.0
+    image: ghcr.io/siderolabs/installer:v1.13.7
   drain:
     force: false
     disableEviction: false

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.7
+    version: v1.13.8
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.0
+    version: v1.13.7
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/kubernetes/bootstrap/talos/patches/controller/disable-admission-controller.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/disable-admission-controller.yaml
@@ -1,2 +1,15 @@
-- op: remove
-  path: /cluster/apiServer/admissionControl
+# Strip Talos's default PodSecurity admission plugin.
+#
+# This was an RFC6902 (JSON) patch, but talhelper refuses JSON6902 patches once
+# the machine config becomes multi-document — which it now is, since the
+# nut-client ExtensionServiceConfig (see talconfig.yaml) adds a second document.
+# So it's expressed as a strategic-merge patch using Talos's `$patch: delete`
+# directive, which removes the whole admissionControl key (same net effect as
+# the old `op: remove`).
+#
+# NOTE: written as `$$patch` because talhelper runs envsubst over patch files;
+# `$$` escapes to a literal `$`, so Talos receives `$patch: delete`.
+cluster:
+  apiServer:
+    admissionControl:
+      $$patch: delete

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
 ---
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.7
+talosVersion: v1.13.8
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.3
 

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -23,18 +23,19 @@ cniConfig:
   name: none
 
 # Talos Image Factory Schematic Extensions (factory.talos.dev)
-# Schematic ID: 4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+# Schematic ID: f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
 # Included extensions:
 #   - siderolabs/gasket-driver  : Google Coral TPU support (PCIe/M.2 accelerators)
 #   - siderolabs/i915           : Intel GPU drivers and firmware
 #   - siderolabs/intel-ucode    : Intel CPU microcode updates
 #   - siderolabs/mei            : Intel Management Engine Interface (required for AMT/vPro)
+#   - siderolabs/nut-client     : NUT upsmon secondary; graceful shutdown on UPS FSD (see extensionServices below)
 
 nodes:
   - hostname: "mj0583jp"
     ipAddress: "192.168.5.40"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -51,7 +52,7 @@ nodes:
   - hostname: "mj0581m7"
     ipAddress: "192.168.5.41"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -68,7 +69,7 @@ nodes:
   - hostname: "mj0583eq"
     ipAddress: "192.168.5.42"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -85,7 +86,7 @@ nodes:
   - hostname: "mj05ajfj"
     ipAddress: "192.168.5.50"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: false
     networkInterfaces:
       - deviceSelector:
@@ -100,7 +101,7 @@ nodes:
   - hostname: "mj04ew44"
     ipAddress: "192.168.5.51"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: false
     networkInterfaces:
       - deviceSelector:
@@ -115,7 +116,7 @@ nodes:
   - hostname: "mj0581rw"
     ipAddress: "192.168.5.52"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: false
     networkInterfaces:
       - deviceSelector:
@@ -130,7 +131,7 @@ nodes:
   - hostname: "mj04968e"
     ipAddress: "192.168.5.53"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: false
     networkInterfaces:
       - deviceSelector:
@@ -145,7 +146,7 @@ nodes:
   - hostname: "mj05g4ub"
     ipAddress: "192.168.5.54"
     installDisk: "/dev/sda"
-    talosImageURL: factory.talos.dev/installer/4ac502d0fe0dcee313870d79c8005e6b99ac55872533f873c704080f035dc6e8
+    talosImageURL: factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0
     controlPlane: false
     networkInterfaces:
       - deviceSelector:
@@ -173,9 +174,32 @@ patches:
 
 # Controller patches
 controlPlane:
+  # NUT (Network UPS Tools) client — runs upsmon as a native Talos service
+  # (siderolabs/nut-client extension) on every node. Each node is a *secondary*
+  # that monitors ups@192.168.5.10 (TrueNAS master, upsd :3493). When the master
+  # signals FSD (~2 min after LOWBATT) the secondary runs SHUTDOWNCMD; Talos's
+  # poweroff path cordons+drains best-effort before powering off.
+  #
+  # The upsmon password is injected from talenv.sops.yaml as ${nut_monpwd} at
+  # `talhelper genconfig` time — never committed in plaintext. This is the same
+  # nut_monpwd the other (non-K8s) secondaries use.
+  #
+  # The &nutClient anchor is reused by the worker group below so all 8 nodes
+  # get an identical upsmon.conf.
+  extensionServices: &nutClient
+    - name: nut-client
+      configFiles:
+        - mountPath: /usr/local/etc/nut/upsmon.conf
+          content: |
+            MONITOR ups@192.168.5.10:3493 1 upsmon ${nut_monpwd} secondary
+            MINSUPPLIES 1
+            SHUTDOWNCMD "/sbin/poweroff"
+            FINALDELAY 0
   patches:
     - "@./patches/controller/api-access.yaml"
     - "@./patches/controller/cluster.yaml"
     - "@./patches/controller/disable-admission-controller.yaml"
     - "@./patches/controller/etcd.yaml"
 
+worker:
+  extensionServices: *nutClient

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
 ---
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.0
+talosVersion: v1.13.7
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.3
 


### PR DESCRIPTION
Closes #1124 (pending rollout + failover test).

## Approach — native Talos `nut-client` extension (not a DaemonSet)

The issue left the mechanism open (DaemonSet vs Talos-native vs kubelet graceful shutdown). I went with the **native `siderolabs/nut-client` system extension**, the community-standard path for NUT on Talos:

- No Talos API credentials, no `talosctl`-in-a-pod, no "the pod shuts down the node it's running on" race.
- Runs `upsmon` as a native Talos service (`ext-nut-client`) on every node.
- Each node is a **secondary** monitoring `ups@192.168.5.10:3493` (TrueNAS master). On the master's **FSD** it runs `SHUTDOWNCMD "/sbin/poweroff"`.
- Talos's poweroff path auto-cordons+drains (best-effort), and the existing kubelet `shutdownGracePeriod: 60s` evicts pods first — covering both (a) monitor and (b) graceful shutdown.

## Changes

- **`talconfig.yaml`**
  - New Image Factory schematic `f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0` — existing 4 extensions **+ `siderolabs/nut-client`** (verified: the old ID reproduces exactly from the existing 4). All 8 `talosImageURL`s bumped.
  - `extensionServices` block (shared by `controlPlane` + `worker` via a `&nutClient` anchor) writes `/usr/local/etc/nut/upsmon.conf`.
  - Password injected as `${nut_monpwd}` from `talenv.sops.yaml` at `talhelper genconfig` time — **never committed in plaintext**.
  - **Talos `v1.13.0` → `v1.13.7`** — since reimaging every node for the extension is already required, folding in the pending patch bump makes it a single roll. Patch-level within the same minor, no breaking changes (pulls in the 1.13.4 etcd client-leak fix). k8s stays `v1.36.3` (already latest 1.36 patch).
- **`tuppr/upgrades/talosupgrade.yaml`** — `version` → `v1.13.7` so the live upgrader stays in sync (+ trailing newline yamllint fix).
- **`patches/controller/disable-admission-controller.yaml`**
  - Converted RFC6902 → strategic-merge `$patch: delete` (written `$$patch` to survive talhelper envsubst). Required because talhelper refuses JSON6902 patches once the config is multi-document (the ExtensionServiceConfig makes it multi-doc). **Net effect is identical** — `admissionControl` still fully removed on all nodes.

> The legacy `plans/` dir isn't wired into the Flux kustomization (tuppr is the active upgrader); the `generate-upgrade-plans` workflow regenerates it from the talconfig version change on this PR.

## Validation

`talhelper genconfig` (v3.1.15) renders cleanly for **all 8 nodes** — each gets the `ExtensionServiceConfig` + correct `upsmon.conf`, `install.image` = `f3350e61…:v1.13.7`, and `admissionControl` is dropped. yamllint passes.

## ⚠️ Human steps remain (do not merge-and-forget)

1. **Add the secret.** Create `kubernetes/bootstrap/talos/talenv.sops.yaml` with the existing `nut_monpwd` and SOPS-encrypt it (covered by the `talos/*.sops.yaml` rule). Without it, `talhelper genconfig` fails with `variable nut_monpwd not set`. Good moment to **rotate** it (it traversed the LAN in plaintext) — update the master's `upsd.users` + every secondary too.
2. **Roll it out.** Re-image each node to the new schematic + version (reboot per node): `task talos:generate-config`, then per node `talosctl upgrade --nodes <ip> --image factory.talos.dev/installer/f3350e61fcd45fab42c5b71062eae42982131a4dcbc7ad83bf86d793121607d0:v1.13.7` (or via tuppr). Verify: `talosctl service ext-nut-client` and `talosctl -n <ip> read /usr/local/etc/nut/upsmon.conf`.
3. **Failover test.** Pull mains briefly and confirm the cascade.

> The pinned `.bin/talhelper` (3.1.6) is too old to parse Talos v1.13.x — genconfig needs a newer talhelper (validated with 3.1.15).

### Caveats
- Single UPS → all 8 nodes power off in parallel on FSD. Staggering (workers-first / CP-last) would need a longer `FINALDELAY` on control planes or a second low-battery threshold on the master; per the issue, parallel is acceptable since the whole lab loses power together.
- Existing `kubernetesTalosAPIAccess` (`os:admin` → `system-upgrade`) is untouched — the NUT path doesn't rely on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)