### PR TITLE
fix(observability): port x509-exporter alert keys to chart 4.2.0

### DIFF
--- a/kubernetes/apps/observability/x509-certificate-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/x509-certificate-exporter/app/helmrelease.yaml
@@ -62,8 +62,18 @@ spec:
       criticalDaysLeft: 7
       # Alert if the exporter itself can't read Secrets / reach the API —
       # otherwise a monitoring regression would go silent.
-      alertOnReadErrors: true
-      readErrorsSeverity: warning
+      #
+      # Chart 4.2.0 split the old single X509ExporterReadErrors alert (and its
+      # alertOnReadErrors / readErrorsSeverity keys, now rejected by the chart's
+      # values.schema.json) into two families: SourceErrors (can't read/parse a
+      # source) and KubeTransportErrors (can't reach the Kubernetes API). Each
+      # gained a *Sustained variant that fires after 30m instead of 5m.
+      alertOnSourceErrors: true
+      sourceErrorsSeverity: warning
+      sourceErrorsSustainedSeverity: critical
+      alertOnKubeTransportErrors: true
+      kubeTransportErrorsSeverity: warning
+      kubeTransportErrorsSustainedSeverity: critical
       certificateRenewalsSeverity: warning
       certificateExpirationsSeverity: critical
   driftDetection:


### PR DESCRIPTION
PR #1195 bumped x509-certificate-exporter to chart 4.2.0, which added a `values.schema.json` with `additionalProperties: false` on `prometheusRules`. The Helm upgrade fails on every reconcile:

```
at '/prometheusRules': additional properties 'readErrorsSeverity', 'alertOnReadErrors' not allowed
```

Flux rolled back, so the exporter is still serving on 4.1.0 — no outage, but the release is stuck.

4.2.0 split the old single `X509ExporterReadErrors` alert (which covered both "can't read files" and "can't authenticate with the Kubernetes API") into two families:

| 4.1.0 | 4.2.0 |
|---|---|
| `alertOnReadErrors` / `readErrorsSeverity` | `alertOnSourceErrors` / `sourceErrorsSeverity` (+ `sourceErrorsSustainedSeverity`) |
| | `alertOnKubeTransportErrors` / `kubeTransportErrorsSeverity` (+ `kubeTransportErrorsSustainedSeverity`) |

This maps the old keys onto both families, preserving the previous `warning` severity for the 5m alerts.

**Behaviour change worth noting:** the new `*Sustained` variants (fire after 30m instead of 5m) are set to the chart's `critical` default. Previously read errors could only ever page at `warning`. Say the word and I'll drop both to `warning` instead.

Verified with `helm template` against chart 4.2.0 (schema passes, alerts render as expected) and `task kubernetes:kubeconform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)