### PR TITLE
fix(meilisearch): rename dumpless-upgrade env var for v1.52.0

### DIFF
--- a/kubernetes/apps/default/meilisearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/meilisearch/app/helmrelease.yaml
@@ -45,7 +45,12 @@ spec:
               # In-place DB migration when engine version > on-disk DB version
               # (required to move past v1.41.0 -> v1.46.1). Safe to keep set;
               # only acts when a version mismatch is detected on startup.
-              MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: "true"
+              #
+              # Renamed upstream from MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE when
+              # the feature left experimental. The old name is silently ignored
+              # rather than rejected, so v1.52.0 simply refused to open the
+              # v1.50.0 database and crashlooped.
+              MEILI_UPGRADE_DB: "true"
             resources:
               requests:
                 cpu: 25m


### PR DESCRIPTION
PR #1162 bumped Meilisearch 1.50.0 -> 1.52.0. The new engine refuses to open the on-disk 1.50.0 database and crashloops:

```
Your database version (1.50.0) is incompatible with your current engine version (1.52.0).
... you can set the `--upgrade-db` flag (or the `MEILI_UPGRADE_DB` environment variable)
```

The HelmRelease already opted into in-place upgrades via `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE`, but upstream renamed that to `MEILI_UPGRADE_DB` when the feature graduated out of experimental. Unknown `MEILI_*` vars are ignored rather than rejected, so the stale name failed silently and the migration never ran.

**This migration is one-way.** `meilisearch-data` has no volsync ReplicationSource, so I took a Ceph snapshot first:

```
NAME                                 READYTOUSE   SOURCEPVC          RESTORESIZE   SNAPSHOTCLASS
meilisearch-data-pre-152-migration   true         meilisearch-data   2Gi           csi-ceph-blockpool
```

To roll back: restore that snapshot into a new PVC and repoint `persistence.data.existingClaim`, then pin the image back to v1.50.0.

Impact while broken: karakeep is `2/2 Running` but its full-text search is degraded — the index is derived data and rebuildable by re-indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)