### PR TITLE
feat(network): Gateway API CRDs v1.6.1, fix cilium ordering

### DIFF
--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -9,6 +9,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: gateway-api-crds
   path: ./kubernetes/apps/kube-system/cilium/app
   prune: false # never should be deleted
   sourceRef:

--- a/kubernetes/apps/network/cilium-gateway/crds/kustomization.yaml
+++ b/kubernetes/apps/network/cilium-gateway/crds/kustomization.yaml
@@ -1,9 +1,25 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# Gateway API standard channel, v1.6.1.
+#
+# Cilium 1.20's operator requires gatewayclasses, gateways, httproutes,
+# grpcroutes, tlsroutes, referencegrants and backendtlspolicies to all serve
+# gateway.networking.k8s.io/v1. If any is missing it does NOT crash — it logs
+# "Required GatewayAPI resources are not found" and disables the Gateway API
+# controller for the life of the process, which silently stops Gateway/HTTPRoute
+# reconciliation and the cert sync into cilium-secrets.
+#
+# v1.6.1 referencegrants still serves v1beta1 as the storage version, so this
+# set satisfies Cilium 1.19 as well and is safe to land ahead of the 1.20 bump.
+#
+# grpcroutes was present in-cluster but missing here (drift); tlsroutes moved
+# from the experimental channel to standard.
 resources:
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml

--- a/kubernetes/apps/network/cilium-gateway/ks.yaml
+++ b/kubernetes/apps/network/cilium-gateway/ks.yaml
@@ -9,8 +9,9 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: cilium
+  # No dependsOn: these are plain CRDs and need nothing from Cilium. The
+  # reverse edge (cilium dependsOn gateway-api-crds) is what matters, since
+  # the operator only probes for Gateway API CRDs at startup.
   path: ./kubernetes/apps/network/cilium-gateway/crds
   prune: false
   sourceRef:


### PR DESCRIPTION
Prep for #1177 (Cilium 1.19.6 -> 1.20.0). **Merge this first; #1177 stays held until this is in and both Gateways are confirmed healthy.**

### Why

Cilium 1.20 requires `referencegrants`, `tlsroutes` and `backendtlspolicies` at `gateway.networking.k8s.io/v1`. Current state:

| CRD | installed | 1.20 needs |
|---|---|---|
| referencegrants | `v1beta1` only | ❌ v1 |
| tlsroutes | `v1alpha2` only | ❌ v1 |
| backendtlspolicies | not installed | ❌ v1 |

**The failure mode is silent.** On a missing CRD the operator does not crash — it logs `Required GatewayAPI resources are not found` and returns `Enabled: false`, disabling the Gateway API controller for the life of the process. Existing CECs keep serving traffic, so this would not be obvious; what stops is Gateway/HTTPRoute reconciliation and the cert sync into `cilium-secrets`, so the wildcard cert would eventually expire with no visible cause.

### Ordering fix

`gateway-api-crds` had `dependsOn: cilium` — backwards. CRDs need nothing from Cilium, and since the operator only probes at startup, merging #1177 under the old ordering would upgrade the chart *before* the CRDs applied and then need a manual operator restart. Reversed so `cilium` dependsOn `gateway-api-crds`.

Tradeoff worth a look: this couples the CNI Kustomization to one that fetches raw.githubusercontent.com. A fetch failure blocks cilium *reconciliation* — it does not touch the running DaemonSet, and `prune: false` means nothing is removed. Drop that hunk if you would rather not have the coupling.

### Verification

- Every new version set covers the cluster's current `status.storedVersions` (`gatewayclasses/gateways/httproutes/grpcroutes` = `v1`, `referencegrants` = `v1beta1`, `tlsroutes` = `v1alpha2`) — no storage-version conflict on apply
- `referencegrants` v1.6.1 serves `v1` **and** `v1beta1` (storage), so this satisfies 1.19.6 too and is safe to land ahead of the bump
- GRPCRoute / TLSRoute / ReferenceGrant object counts are all **zero**, so the `grpcroutes` v1alpha2 drop migrates nothing
- No dependency cycle: `gateway-api-crds` -> (none), `cilium` -> `gateway-api-crds`, `cilium-config` -> `cilium`
- `task kubernetes:kubeconform` passes; yamllint clean

`grpcroutes` was live in-cluster but absent from Git (drift) — now tracked. `tlsroutes` moves from the experimental channel to standard.

### After merge

Confirm before #1177:
```
kubectl get crd referencegrants.gateway.networking.k8s.io -o jsonpath="{.spec.versions[*].name}"   # expect v1 v1beta1
kubectl get crd backendtlspolicies.gateway.networking.k8s.io                                        # expect exists
kubectl get gateway -A                                                                              # both PROGRAMMED=True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)