### PR TITLE
fix(loki): write sidecar rules to the tenant folder

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -106,6 +106,12 @@ spec:
         repository: ghcr.io/kiwigrid/k8s-sidecar
       rules:
         searchNamespace: ALL
+        # The ruler's `local` store reads <directory>/<tenant>, and with
+        # auth_enabled: false the tenant is `fake`. The chart's sidecar folder
+        # defaults to /rules, so every rule file landed one level too high and
+        # Loki logged "unable to read rule dir /rules/fake: no such file or
+        # directory" and evaluated nothing — no alerts, no recording rules.
+        folder: /rules/fake
     singleBinary:
       persistence:
         enabled: true


### PR DESCRIPTION
Found while reviewing #1150 — the new "Logs / Overview" dashboard would have rendered completely empty, and the reason turned out to be a much bigger pre-existing problem.

### The bug

Loki's ruler with `storage.type: local` reads `<directory>/<tenant>`. With `auth_enabled: false` the tenant is `fake`, so it reads `/rules/fake`. The chart's `sidecar.rules.folder` defaults to `/rules`, and this repo never overrode it — so the k8s-sidecar wrote every rule file one level too high.

Verified in-cluster:

```
$ kubectl exec -n observability loki-0 -c loki-sc-rules -- ls /rules
autobrr.yaml  cert-manager.yaml  emqx.yaml  flux.yaml  frigate.yaml
home-assistant.yaml  ingress-nginx.yaml  paperless.yaml  qbittorrent.yaml
radarr.yaml  recording-rules.yaml  rook-ceph.yaml  sonarr.yaml  zigbee2mqtt.yaml
$ find /rules -maxdepth 2 -type d
/rules                      # no /rules/fake

$ curl -s localhost:3100/loki/api/v1/rules
unable to read rule dir /rules/fake: open /rules/fake: no such file or directory
$ curl -s localhost:3100/prometheus/api/v1/rules
{"status":"success","data":{"groups":[]}}
```

### Impact

**All 14 `loki_rule` ConfigMaps have been silently dead** — every Loki-based alert (flux, cert-manager, rook-ceph, ingress-nginx, emqx, frigate, home-assistant, paperless, qbittorrent, the *arrs, zigbee2mqtt) plus both recording-rule groups. Zero rules evaluated, zero alerts capable of firing.

This also explains the missing `loki:*` series in Prometheus: `rulerConfig.remote_write.enabled: true` is set and correct, but there were no recording rules running to remote-write anything.

The ConfigMaps, labels (`loki_rule: "true"`), `searchNamespace: ALL`, and the alertmanager/remote_write config were all fine — only the folder was wrong.

### After merge

```
kubectl exec -n observability loki-0 -c loki-sc-rules -- ls /rules/fake     # 14 files
kubectl exec -n observability loki-0 -c loki-sc-rules -- \
  wget -qO- localhost:3100/prometheus/api/v1/rules | head                    # non-empty groups
```
Then `loki:app_log_errors:1m` and friends should appear in Prometheus within a couple of evaluation intervals, which is also what #1150's "Logs / Overview" dashboard needs.

`task kubernetes:kubeconform` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)