### PR TITLE
fix(observability): enable Prometheus remote-write receiver properly

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -382,7 +382,14 @@ spec:
         enableAdminAPI: true
         enableFeatures:
           - memory-snapshot-on-shutdown
-          - remote-write-receiver
+        # Prometheus 3 dropped `remote-write-receiver` as a feature flag in
+        # favour of --web.enable-remote-write-receiver, which the operator
+        # exposes as this field. Listing it under enableFeatures silently did
+        # nothing, so Loki's ruler remote_write got
+        #   404: remote write receiver needs to be enabled with
+        #        --web.enable-remote-write-receiver
+        # and no loki:* recording-rule series ever reached Prometheus.
+        enableRemoteWriteReceiver: true
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         query:


### PR DESCRIPTION
Last link in the Loki ruler chain, after #1201 got the rules loading again.

### The bug

Prometheus 3 dropped `remote-write-receiver` as a **feature flag** in favour of `--web.enable-remote-write-receiver`, which prometheus-operator exposes as `prometheusSpec.enableRemoteWriteReceiver` (chart default `false`).

Listing it under `enableFeatures` therefore does nothing. The live pod runs Prometheus **v3.13.2** with `--enable-feature=memory-snapshot-on-shutdown,remote-write-receiver`, and the write endpoint still 404s:

```
level=error caller=handler.go:87 manager=tenant-wal instance=fake component=remote
  remote_name=fake-rw-prometheus
  url=http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/write
  failedSampleCount=2
  err="server returned HTTP status 404 Not Found: remote write receiver needs to be
       enabled with --web.enable-remote-write-receiver"
```

### Why it matters

#1201 fixed the ruler folder, so all 14 rule groups (27 rules) now load and evaluate — confirmed in the logs:

```
rule_name=loki:app_log_errors:1m rule_type=recording total=0.050847266
rule_name=FluxSourceError          rule_type=alerting
rule_name=SonarrApplicationError   rule_type=alerting
```

Alerting works from here (it goes straight to Alertmanager). But the **recording** rules deliver via remote_write, so `loki:app_log_errors:1m`, `loki:app_log_lines:1m`, `loki:namespace_log_bytes:5m`, `loki:ingress_5xx:5m` and `loki:ingress_requests:5m` still never reach Prometheus — which is exactly what the "Logs / Overview" dashboard from #1150 queries.

### Note

This restarts the Prometheus StatefulSet. Data is on a PVC and preserved; expect a brief scrape gap.

`task kubernetes:kubeconform` passes. (yamllint flags a pre-existing long line at `helmrelease.yaml:68`, unrelated and present on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)