### PR TITLE
fix(rook-ceph): silence rook mgr module debug logging

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -60,6 +60,18 @@ spec:
       isDefault: false
       name: csi-ceph-blockpool
     cephClusterSpec:
+      # The rook orchestrator module logs every Kubernetes API response body at
+      # DEBUG. A full PodList is ~1.5MiB and it polls every 15s (~6MiB/min,
+      # ~8.6GiB/day). Loki rejected each one against its 256KiB max entry size
+      # ("max entry size '262144' bytes exceeded ... entry with length
+      # '1574250' bytes"), so ceph-mgr logs were dropped outright rather than
+      # truncated — the active mgr was effectively unlogged.
+      #
+      # The option only takes effect when the module reloads, which the
+      # 8-hourly `ceph mgr fail` in mgr-maintenance/ already does.
+      cephConfig:
+        mgr:
+          mgr/rook/log_level: info
       crashCollector:
         disable: false
       csi:


### PR DESCRIPTION
Root cause of the ceph-mgr log drops.

### What is happening

The rook orchestrator module logs every Kubernetes API **response body** at DEBUG. A full `PodList` is ~1.5MiB and it polls every 15s — roughly **6MiB/min, ~8.6GiB/day** from one container:

```
debug 2026-08-09T18:04:26.587+0000 ... 0 [mgr DEBUG mgr] response body: {"kind":"PodList",...}
```

Loki rejects each one against its 256KiB `max entry size`:

```
max entry size '262144' bytes exceeded for stream '{app="ceph-mgr",...}'
while adding an entry with length '1574250' bytes
```

Rejection **drops the whole entry** rather than truncating, so the active mgr has effectively been unlogged in Loki — ~20 rejections every 5 minutes, and none of its real output getting through.

### Fix

Nothing in Git or the mon config store set a debug level — `mgr/rook/log_level` was simply unset, and the module defaults to DEBUG. Pinning it to `info` via `spec.cephConfig` (supported on this CRD, previously empty) makes it declarative instead of a manual `ceph config set`.

### Applying it

I set `mgr/rook/log_level=info` live to confirm it is the right knob, but **it only takes effect on module reload** — verified still spamming ~3.5 min after the config change. The 8-hourly `ceph mgr fail` CronJob in `mgr-maintenance/` performs exactly that reload, so **this self-applies within 8 hours** with no action needed.

To apply immediately instead:
```
kubectl exec -n rook-ceph deploy/rook-ceph-tools -- ceph mgr fail
```
(I did not run this — Ceph mutations are gated per AGENTS.md.)

Paired with #1204, which makes Loki truncate oversized lines rather than discard them, so a future chatty container degrades instead of going silent.

`task kubernetes:kubeconform` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)