### PR TITLE
fix(loki): truncate oversized lines instead of dropping them

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -52,6 +52,13 @@ spec:
       limits_config:
         # Relaxed 3d -> 30d after Ceph capacity expansion (~3.6TiB, ~6% used).
         retention_period: 30d
+        # Keep oversized lines instead of discarding them. By default Loki
+        # rejects any entry over max_line_size (256KB) outright, so a single
+        # chatty container silently loses ALL of its logs — which is what the
+        # rook mgr module's 1.5MiB DEBUG dumps did to ceph-mgr (see #1203).
+        # Truncating degrades one line instead of blinding a whole stream.
+        max_line_size: 256KB
+        max_line_size_truncate: true
       schemaConfig:
         configs:
           - from: '2024-04-01'


### PR DESCRIPTION
Defence-in-depth half of the ceph-mgr log-drop fix. #1203 stops the spam at source; this makes the failure mode survivable in general.

### Why

Loki rejects any entry over `max_line_size` (256KB) **outright**. The whole entry is discarded, not trimmed — so one chatty container silently loses *all* of its logs, not just the offending line.

That is what happened to ceph-mgr: the rook mgr module emits ~1.5MiB DEBUG dumps every 15s, every one was rejected, and the active mgr was effectively unlogged in Loki.

`max_line_size_truncate: true` keeps the first 256KB and drops the remainder, so the stream stays usable and the failure degrades one line instead of blinding a whole app.

`max_line_size` is set explicitly at its current default so the pair reads as a deliberate policy rather than a lone flag.

### Verification

Both keys confirmed against the running Loki **3.6.11** `/config` endpoint (current effective values `max_line_size: 256KB`, `max_line_size_truncate: false`).

`task kubernetes:kubeconform` passes. (yamllint flags two pre-existing long lines at `helmrelease.yaml:41,50` — present on main, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)