### PR TITLE
fix(rook-ceph): loosen hair-trigger BlueStore slow-op alert

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -72,6 +72,22 @@ spec:
       cephConfig:
         mgr:
           mgr/rook/log_level: info
+        osd:
+          # BLUESTORE_SLOW_OP_ALERT ships hair-trigger defaults: a SINGLE op
+          # over bluestore_log_op_age (5s) latches HEALTH_WARN for a full 24h
+          # (threshold 1, lifetime 86400). One transient stall during a node
+          # reboot or an OSD restart therefore parks the cluster in HEALTH_WARN
+          # all day — which matters here because tuppr's TalosUpgrade gates on
+          # `status.ceph.health in ['HEALTH_OK']`, so a stale blip silently
+          # blocks node upgrades.
+          #
+          # Widen "slow" to 10s, require a handful of occurrences rather than
+          # one, and let a one-off age out in an hour. A genuinely degraded
+          # device produces slow ops continuously and still trips the alert;
+          # only the single-sample latch is suppressed.
+          bluestore_log_op_age: "10"
+          bluestore_slow_ops_warn_threshold: "5"
+          bluestore_slow_ops_warn_lifetime: "3600"
       crashCollector:
         disable: false
       csi:


### PR DESCRIPTION
Found while working out why #1151 would not roll.

### The problem

`BLUESTORE_SLOW_OP_ALERT` ships defaults that latch very aggressively:

| option | default | effect |
|---|---|---|
| `bluestore_log_op_age` | `5.0` s | what counts as a "slow" op |
| `bluestore_slow_ops_warn_threshold` | `1` | **one** slow op trips the warning |
| `bluestore_slow_ops_warn_lifetime` | `86400` s | it sticks for **24h** |

One transient stall during a node reboot or OSD restart therefore parks the whole cluster in `HEALTH_WARN` for a full day.

That is not cosmetic here — tuppr's `TalosUpgrade` gates on:

```yaml
- apiVersion: ceph.rook.io/v1
  kind: CephCluster
  expr: status.ceph.health in ['HEALTH_OK']
```

so a stale single-sample blip **silently blocks every Talos node upgrade**.

### Not masking a real fault

It is currently firing for `osd.2`, which is the *fastest* OSD in the cluster:

```
osd  commit_latency(ms)  apply_latency(ms)
  2                   2                  2     <- the "slow" one
  5                  26                 26
  6                  15                 15
```

So this is a latched historical event — almost certainly one op during today's OSD restarts — not a degraded device.

### The change

Widen "slow" to 10s, require 5 occurrences instead of 1, and let a one-off age out in an hour. A genuinely failing device produces slow ops *continuously* and still trips the alert; only the single-sample 24h latch is suppressed.

### Note

This alone will not reach `HEALTH_OK` — `RECENT_CRASH` (mon.k, msgr2 `ProtocolV2::reset_session` crash at 06:25 today) is also outstanding and needs `ceph crash archive-all`, which is a gated Ceph mutation.

`task kubernetes:kubeconform` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)