### PR TITLE
fix(system-upgrade): pin tuppr upgrade jobs off the target node

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,6 +10,19 @@ spec:
     version: v1.13.8
   policy:
     rebootMode: powercycle
+    # Never let the upgrade Job land on the node it is upgrading. The default
+    # is `soft` — "prefers to avoid but CAN run on the target node" — and when
+    # it does, tuppr's own cordon/drain evicts the Job mid-flight and the
+    # upgrade fails with the node left at its old version.
+    #
+    # This bit us on the v1.13.0 -> v1.13.8 roll: mj04ew44 failed with
+    # "Upgrade Job failed while node remained at v1.13.0", which stopped the
+    # batch after 3 of 8 nodes and left the node cordoned with its OSD
+    # evicted (Ceph degraded until manually uncordoned).
+    #
+    # `hard` makes avoidance a scheduling requirement. With 8 nodes there is
+    # always somewhere else to run.
+    placement: hard
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource


### PR DESCRIPTION
Follow-up to the failed v1.13.0 -> v1.13.8 roll from #1151.

### What happened

The roll upgraded 3 of 8 nodes, then **mj04ew44 failed twice** (backoffLimit 2) and tuppr went terminal-`Failed`, stopping the batch:

```
Failed off-target Job left node at its previous version
  node=mj04ew44 currentVersion=v1.13.0 targetVersion=v1.13.8
Node upgrade failed: Upgrade Job failed while node remained at v1.13.0
```

Stopping the batch was correct. But tuppr left the node **cordoned with its OSD evicted**, so Ceph sat degraded until it was manually uncordoned:

```
PG_DEGRADED: 9553/225018 objects degraded (4.245%), 25 pgs degraded, 39 pgs undersized
OSD_DOWN / OSD_HOST_DOWN: osd.5 (host=mj04ew44)
```

### The change

`policy.placement` defaults to `soft`, which per tuppr's own CRD schema means:

> soft: preferred avoidance (job prefers to avoid but **can run on the target node**)

When the Job lands on the node being upgraded, tuppr's own cordon/drain evicts it mid-flight and the upgrade fails exactly as observed. `hard` makes avoidance a scheduling requirement — with 8 nodes there is always somewhere else to run.

### Honest caveat

tuppr **deletes the Job pods on failure** (`Deleting terminal job`), so the actual error output was gone before it could be read. This is the strongest remaining hypothesis, not a confirmed root cause. Two other theories were tested and **disproved**:

- *Differing schematic on that node* — all 8 nodes carry the identical `4ac502d0…`
- *A stuck `noup` flag blocking the OSD* — the flag was `noout`, which is protective and unrelated

It is correct hardening regardless: an upgrade job that can be killed by its own drain is a latent failure mode that would keep recurring at random.

### Retry

Editing the spec bumps `metadata.generation` past `status.observedGeneration` (both currently 5), which should pull tuppr out of its terminal state and retry the remaining 5 nodes. Ceph is back to `HEALTH_OK` with 8/8 OSDs and the `noout` flag cleared, so the health gate will pass.

`task kubernetes:kubeconform` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)