### PR TITLE
fix(emqx): give the core PodDisruptionBudget an actual budget

### DIFF
--- a/kubernetes/apps/database/emqx/cluster/cluster.yaml
+++ b/kubernetes/apps/database/emqx/cluster/cluster.yaml
@@ -50,6 +50,21 @@ spec:
         reloader.stakater.com/auto: "true"
     spec:
       replicas: 3
+      # The operator copies these straight into the emqx-core
+      # PodDisruptionBudget (add_pdb.go: MinAvailable/MaxUnavailable come from
+      # coreTemplate.spec). With both unset it emitted a PDB carrying only a
+      # selector — and a PDB with neither budget field leaves expectedPods at 0,
+      # which makes the disruption controller pin disruptionsAllowed to 0 and
+      # deny EVERY eviction, forever.
+      #
+      # That silently blocked `kubectl drain` on any node running a core pod,
+      # which stalled the Talos v1.13.8 roll: the installer succeeded but the
+      # drain timed out evicting emqx-core-1, so tuppr failed the node and
+      # stopped the batch at 3 of 8.
+      #
+      # maxUnavailable (rather than minAvailable) so it keeps scaling correctly
+      # if replicas change; 1 of 3 keeps Mnesia quorum during a rolling drain.
+      maxUnavailable: 1
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Root cause of the stalled Talos v1.13.8 roll (#1151). **Not an operator bug** — a value the CR never supplied.

### What the operator does

`controllers/apps/v2beta1/add_pdb.go` @ 2.2.29 copies the budget straight off the EMQX CR:

```go
Spec: policyv1.PodDisruptionBudgetSpec{
    Selector:       &metav1.LabelSelector{...},
    MinAvailable:   instance.Spec.CoreTemplate.Spec.MinAvailable,
    MaxUnavailable: instance.Spec.CoreTemplate.Spec.MaxUnavailable,
}
```

`coreTemplate.spec` set neither, so the emitted PDB had **only a selector**:

```
NAME        MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS
emqx-core   N/A             N/A               0

currentHealthy=3  desiredHealthy=0  expectedPods=0  disruptionsAllowed=0
```

A PDB with no budget field never gets `expectedPods` computed — Kubernetes' disruption controller only calculates it inside the `minAvailable`/`maxUnavailable` branches — and then pins `disruptionsAllowed` to 0 when `expectedPods <= 0`. The result is a permanent **deny-all on evictions**.

### The damage

`kubectl drain` blocked on any node running a core pod. The Talos installer completed fine — the *drain* is what failed:

```
192.168.5.51: installation of v1.13.8 complete
192.168.5.51: Exit code: 0
mj04ew44: draining node
mj04ew44: evicting pod database/emqx-core-7f986c5d46-1        (×3)
error draining node "mj04ew44": error when evicting pods/"emqx-core-7f986c5d46-1"
  -n "database": client rate limiter Wait returned an error:
  rate: Wait(n=1) would exceed context deadline
```

tuppr then failed the node and stopped the batch at **3 of 8**. Three of the five remaining nodes host a core pod, so this would have recurred on each.

Worth noting the PDB was created `2026-06-16T15:09:20Z` — ~45 min *after* the previous Talos roll finished (14:24). That roll predates the PDB, which is why this never bit before.

### The fix

`maxUnavailable: 1` rather than `minAvailable: 2` so it keeps scaling correctly if `replicas` changes. 1 of 3 preserves Mnesia quorum during a rolling drain.

This needed no operator upgrade — relevant given `<2.3.0` is deliberately held (2.3.x polls the Enterprise-only `load_rebalance` API and breaks OSS EMQX).

### After merge

```
kubectl get pdb emqx-core -n database    # expect MAX UNAVAILABLE=1, ALLOWED DISRUPTIONS=1
```
Then the Talos roll can resume for the remaining 5 nodes.

`task kubernetes:kubeconform` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)