### PR TITLE
feat(default): restore convertx, manyfold, sosse, spoolman

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  # Removed: convertx, manyfold, sosse, spoolman (unused apps)
+  - ./convertx/ks.yaml
   - ./dahua-companion/ks.yaml
   - ./frigate/ks.yaml
   - ./go2rtc/ks.yaml
@@ -11,10 +11,13 @@ resources:
   - ./homepage/ks.yaml
   - ./karakeep/ks.yaml
   - ./litellm/ks.yaml
+  - ./manyfold/ks.yaml
   - ./mealie/ks.yaml
   - ./meilisearch/ks.yaml
   - ./paperless/ks.yaml
   # paperless-gpt/ks.yaml missing — re-add when the Flux Kustomization is authored
+  - ./sosse/ks.yaml
+  - ./spoolman/ks.yaml
   - ./stirling-pdf/ks.yaml
   - ./unifi/ks.yaml
   - ./zigbee2mqtt/ks.yaml

--- a/kubernetes/apps/volsync-system/volsync-canary/app/configmap.yaml
+++ b/kubernetes/apps/volsync-system/volsync-canary/app/configmap.yaml
@@ -25,7 +25,11 @@ metadata:
 data:
   identities: |
     # default namespace
+    convertx@default:3:hourly Volsync RS
     frigate@default:3:hourly Volsync RS
+    manyfold@default:3:hourly Volsync RS
+    sosse@default:3:hourly Volsync RS
+    spoolman@default:3:hourly Volsync RS
     home-assistant@default:3:hourly Volsync RS
     homebox@default:30:daily Volsync RS
     karakeep@default:30:daily Volsync RS


### PR DESCRIPTION
Re-wire the four app trees that were commented out of the namespace
kustomization in January but never deleted (Flux hasn't reconciled them
since; CI and Renovate kept them valid). Their kopia volsync snapshots
predate the May restic->kopia migration, so the bootstrap
ReplicationDestinations will restore empty and the apps start fresh —
except sosse, whose Postgres database is recreated/reused via CNPG.
All four join the volsync canary watch (hourly, threshold 3h).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
