### PR TITLE
feat(cert-manager): network-policies phase 1 — first consumer of the shared templates

### DIFF
--- a/kubernetes/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./cert-manager/ks.yaml
+  - ./network-policies/ks.yaml

--- a/kubernetes/apps/cert-manager/network-policies/app/egress-acme.yaml
+++ b/kubernetes/apps/cert-manager/network-policies/app/egress-acme.yaml
@@ -1,0 +1,24 @@
+---
+# cert-manager-specific egress on top of the shared default-deny stack:
+# - 443/tcp anywhere: Let's Encrypt ACME API + Cloudflare API (DNS-01)
+# - 53/udp+tcp anywhere: cert-manager checks DNS-01 propagation by querying
+#   the AUTHORITATIVE nameservers directly, not just cluster DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-acme
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/kubernetes/apps/cert-manager/network-policies/app/ingress-webhook.yaml
+++ b/kubernetes/apps/cert-manager/network-policies/app/ingress-webhook.yaml
@@ -1,0 +1,22 @@
+---
+# The kube-apiserver calls the cert-manager webhook for admission of every
+# cert-manager.io resource. Under default-deny that call is dropped and ALL
+# Certificate/Issuer operations cluster-wide start failing — this is the
+# single most dangerous gap when locking down this namespace. The apiserver
+# runs on host network, so a plain NetworkPolicy cannot select it; Cilium's
+# kube-apiserver entity handles it correctly.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-webhook-from-apiserver
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/apps/cert-manager/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/network-policies/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../templates/network-policies/default-deny
+  - ../../../../templates/network-policies/allow-dns
+  - ../../../../templates/network-policies/allow-kube-apiserver
+  - ../../../../templates/network-policies/allow-from-monitoring
+  - ./egress-acme.yaml
+  - ./ingress-webhook.yaml

--- a/kubernetes/apps/cert-manager/network-policies/ks.yaml
+++ b/kubernetes/apps/cert-manager/network-policies/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cert-manager-network-policies
+  namespace: flux-system
+spec:
+  targetNamespace: cert-manager
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager
+  path: ./kubernetes/apps/cert-manager/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  timeout: 5m


### PR DESCRIPTION
Starts the rollout the templates/network-policies README planned in April:
cert-manager gets default-deny + allow-dns + allow-kube-apiserver +
allow-from-monitoring from the shared bases, plus two namespace-specific
policies:

- allow-egress-acme: 443/tcp anywhere (Let's Encrypt + Cloudflare API) and
  53 udp+tcp anywhere — cert-manager verifies DNS-01 propagation against
  authoritative nameservers directly, not only cluster DNS.
- allow-webhook-from-apiserver (CiliumNetworkPolicy, kube-apiserver
  entity): the apiserver calls the cert-manager webhook for admission of
  every cert-manager.io resource; blocking it would break Certificate
  operations cluster-wide. Webhook pod label and port verified against the
  live cluster.

DELIBERATELY LEFT UNMERGED for owner review: this is the first
traffic-enforcing change in the cluster. Suggested validation after merge:
`cmctl renew` one certificate (or wait for a renewal) and confirm the
webhook answers (`kubectl apply --dry-run=server` on any Certificate).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
