### PR TITLE
feat(litellm): move to CNPG Postgres for virtual keys and spend tracking

### DIFF
--- a/kubernetes/apps/default/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/default/litellm/app/externalsecret.yaml
@@ -15,6 +15,14 @@ spec:
       data:
         ANTHROPIC_API_KEY: "{{ .ANTHROPIC_API_KEY }}"
         LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        # Postgres for virtual keys / spend tracking (was running config-only)
+        DATABASE_URL: "postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASSWORD }}@postgres16-rw.database.svc.cluster.local:5432/litellm"
+        STORE_MODEL_IN_DB: "True"
+        INIT_POSTGRES_DBNAME: litellm
+        INIT_POSTGRES_HOST: postgres16-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .LITELLM_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPERUSER_PASSWORD }}"
   data:
     - secretKey: ANTHROPIC_API_KEY
       remoteRef:
@@ -22,3 +30,12 @@ spec:
     - secretKey: LITELLM_MASTER_KEY
       remoteRef:
         key: LITELLM_MASTER_KEY
+    - secretKey: LITELLM_POSTGRES_USER
+      remoteRef:
+        key: LITELLM_POSTGRES_USER
+    - secretKey: LITELLM_POSTGRES_PASSWORD
+      remoteRef:
+        key: LITELLM_POSTGRES_PASSWORD
+    - secretKey: POSTGRES_SUPERUSER_PASSWORD
+      remoteRef:
+        key: POSTGRES_SUPERUSER_PASSWORD

--- a/kubernetes/apps/default/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/default/litellm/app/helmrelease.yaml
@@ -26,6 +26,21 @@ spec:
       litellm:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.4@sha256:ebd9d30add17acdf935d73eb004758c7dfd9388aaa605fda70ad74378ab92aec
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: litellm-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
         containers:
           app:
             image:

--- a/kubernetes/apps/default/litellm/ks.yaml
+++ b/kubernetes/apps/default/litellm/ks.yaml
@@ -11,6 +11,7 @@ spec:
   path: ./kubernetes/apps/default/litellm/app
   dependsOn:
     - name: external-secrets-stores
+    - name: cloudnative-pg-cluster
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
litellm was running config-only with no database — virtual keys, spend
logs, and model DB features silently unavailable. Standard house pattern:
postgres-init initContainer, DATABASE_URL + INIT_POSTGRES_* templated into
the ExternalSecret from new LITELLM_POSTGRES_* flat secrets, and
cloudnative-pg-cluster in dependsOn.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
