### PR TITLE
feat(external-secrets): network-policies phase 2

### DIFF
--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./external-secrets/ks.yaml
+  - ./network-policies/ks.yaml

--- a/kubernetes/apps/external-secrets/network-policies/app/egress-bitwarden.yaml
+++ b/kubernetes/apps/external-secrets/network-policies/app/egress-bitwarden.yaml
@@ -1,0 +1,20 @@
+---
+# ESO's Bitwarden Secrets Manager provider talks to the Bitwarden SaaS API
+# (vault/api/identity.bitwarden.com) — 443/tcp egress. Every secret in the
+# cluster flows through this namespace, so this is the one internet egress
+# that must never be accidentally cut.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-bitwarden
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 443
+          protocol: TCP

--- a/kubernetes/apps/external-secrets/network-policies/app/ingress-webhook.yaml
+++ b/kubernetes/apps/external-secrets/network-policies/app/ingress-webhook.yaml
@@ -1,0 +1,21 @@
+---
+# The kube-apiserver calls the external-secrets webhook (conversion +
+# validation for every ExternalSecret/ClusterSecretStore operation). Same
+# pattern and rationale as cert-manager's phase-1 policy: the apiserver is
+# host-network, so Cilium's kube-apiserver entity is the correct selector.
+# Service external-secrets-webhook:443 -> containerPort 10250.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-webhook-from-apiserver
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-webhook
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/apps/external-secrets/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/network-policies/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../templates/network-policies/default-deny
+  - ../../../../templates/network-policies/allow-dns
+  - ../../../../templates/network-policies/allow-kube-apiserver
+  - ../../../../templates/network-policies/allow-from-monitoring
+  - ../../../../templates/network-policies/allow-intra-namespace
+  - ./egress-bitwarden.yaml
+  - ./ingress-webhook.yaml

--- a/kubernetes/apps/external-secrets/network-policies/ks.yaml
+++ b/kubernetes/apps/external-secrets/network-policies/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-network-policies
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./kubernetes/apps/external-secrets/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/templates/network-policies/allow-intra-namespace/kustomization.yaml
+++ b/kubernetes/templates/network-policies/allow-intra-namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./policy.yaml

--- a/kubernetes/templates/network-policies/allow-intra-namespace/policy.yaml
+++ b/kubernetes/templates/network-policies/allow-intra-namespace/policy.yaml
@@ -1,0 +1,20 @@
+---
+# Allow all pod-to-pod traffic WITHIN the namespace this is applied to.
+# Needed wherever components talk to each other in-namespace (e.g. the
+# external-secrets controller -> bitwarden-sdk-server hop). Cross-namespace
+# traffic stays governed by the other policies.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}


### PR DESCRIPTION
Second consumer of the shared bases per the README rollout order. New
reusable allow-intra-namespace base (the ESO controller must reach
bitwarden-sdk-server:9998 in-namespace, which default-deny would sever),
plus namespace-specific policies: 443 egress for the Bitwarden SaaS API
(every cluster secret flows through here) and the apiserver->webhook
CiliumNetworkPolicy mirroring cert-manager's phase-1 pattern (webhook
labels/ports verified against the live cluster).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
