### PR TITLE
feat(observability): network-policies phase 3

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./network-policies/ks.yaml
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations

--- a/kubernetes/apps/observability/network-policies/app/egress-open.yaml
+++ b/kubernetes/apps/observability/network-policies/app/egress-open.yaml
@@ -1,0 +1,18 @@
+---
+# Observability legitimately talks to EVERYTHING: Prometheus scrapes every
+# namespace plus host-network targets (node-exporter, kubelet, Talos, LAN
+# hosts), gatus probes cluster services, LAN endpoints, and external URLs,
+# alertmanager pushes to Pushover, Grafana reaches its datasources. An
+# itemized egress list here would be permanently wrong. The namespace's win
+# is INGRESS control (only ingress-nginx, monitoring, intra-ns, and the LAN
+# may connect in) — egress stays open by explicit decision.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-open
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - {}

--- a/kubernetes/apps/observability/network-policies/app/ingress-flux-alerts.yaml
+++ b/kubernetes/apps/observability/network-policies/app/ingress-flux-alerts.yaml
@@ -1,0 +1,22 @@
+---
+# Flux's notification-controller (flux-system) POSTs to
+# alertmanager-operated:9093 for every namespace's Alert provider — without
+# this, default-deny silently kills all Flux alerting.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alertmanager-from-flux
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: flux-system
+      ports:
+        - port: 9093
+          protocol: TCP

--- a/kubernetes/apps/observability/network-policies/app/ingress-lan.yaml
+++ b/kubernetes/apps/observability/network-policies/app/ingress-lan.yaml
@@ -1,0 +1,17 @@
+---
+# LAN hosts push into this namespace directly: the Prometheus remote-write
+# receiver (enabled in fc7bed75) ingests from non-cluster machines, and LAN
+# clients hit dashboards via LoadBalancer IPs. The LAN is the trust boundary
+# of this homelab; other CLUSTER namespaces remain blocked by default-deny.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-lan
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.5.0/24

--- a/kubernetes/apps/observability/network-policies/app/ingress-webhook.yaml
+++ b/kubernetes/apps/observability/network-policies/app/ingress-webhook.yaml
@@ -1,0 +1,19 @@
+---
+# The kube-apiserver calls the prometheus-operator admission webhook to
+# validate every PrometheusRule apply — same pattern as cert-manager and
+# external-secrets phases. containerPort 10250 verified live.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-operator-webhook-from-apiserver
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/apps/observability/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/observability/network-policies/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../templates/network-policies/default-deny
+  - ../../../../templates/network-policies/allow-dns
+  - ../../../../templates/network-policies/allow-kube-apiserver
+  - ../../../../templates/network-policies/allow-intra-namespace
+  - ../../../../templates/network-policies/allow-from-ingress
+  - ../../../../templates/network-policies/allow-from-monitoring
+  - ./egress-open.yaml
+  - ./ingress-lan.yaml
+  - ./ingress-webhook.yaml
+  - ./ingress-flux-alerts.yaml

--- a/kubernetes/apps/observability/network-policies/ks.yaml
+++ b/kubernetes/apps/observability/network-policies/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app observability-network-policies
+  namespace: flux-system
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+  path: ./kubernetes/apps/observability/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  timeout: 5m


### PR DESCRIPTION
Ingress-focused posture: observability's egress is deliberately open (an
itemized list of Prometheus scrape targets, gatus probes, and datasource
endpoints would be permanently wrong — documented in egress-open.yaml).
Ingress locks to: ingress-nginx controllers, monitoring self-scrapes,
intra-namespace, the LAN CIDR (remote-write receiver + LoadBalancer
clients), the apiserver->prometheus-operator admission webhook (Cilium
entity, port verified live), and flux-system->alertmanager:9093 (every
namespace's Flux Alert provider posts there — default-deny would have
silently killed Flux alerting).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
