### PR TITLE
fix(gatus): set NAMESPACE for the two GATUS_URL-only template consumers

### DIFF
--- a/kubernetes/apps/default/unifi/ks.yaml
+++ b/kubernetes/apps/default/unifi/ks.yaml
@@ -31,3 +31,4 @@ spec:
       # Stats DB writes constantly but losing a few hours of network stats is
       # acceptable. Back up every 6 hours instead of hourly.
       VOLSYNC_SCHEDULE: "0 */6 * * *"
+      NAMESPACE: default

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -23,3 +23,4 @@ spec:
       APP: *app
       GATUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/-/healthy
       GATUS_SUBDOMAIN: prometheus
+      NAMESPACE: observability


### PR DESCRIPTION
Flux's strict envsubst parses the fallback branch of
${GATUS_URL:-http://${APP}.${NAMESPACE}...} even when GATUS_URL is set,
so kube-prometheus-stack and unifi (the only two adopters relying on
GATUS_URL alone) failed postBuild with 'variable not set: NAMESPACE' —
local flux build is not strict, which is why per-app render verification
passed while the live kustomizations stalled in 'post'.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
