### PR TITLE
fix(netpol): allow node identities — LB traffic and cross-node webhooks were dropped

### DIFF
--- a/kubernetes/apps/cert-manager/network-policies/app/ingress-webhook.yaml
+++ b/kubernetes/apps/cert-manager/network-policies/app/ingress-webhook.yaml
@@ -16,6 +16,8 @@ spec:
   ingress:
     - fromEntities:
         - kube-apiserver
+        - host
+        - remote-node
       toPorts:
         - ports:
             - port: "10250"

--- a/kubernetes/apps/database/network-policies/app/ingress-webhooks.yaml
+++ b/kubernetes/apps/database/network-policies/app/ingress-webhooks.yaml
@@ -13,6 +13,8 @@ spec:
   ingress:
     - fromEntities:
         - kube-apiserver
+        - host
+        - remote-node
       toPorts:
         - ports:
             - port: "9443"
@@ -29,6 +31,8 @@ spec:
   ingress:
     - fromEntities:
         - kube-apiserver
+        - host
+        - remote-node
       toPorts:
         - ports:
             - port: "9443"

--- a/kubernetes/apps/database/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/database/network-policies/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../templates/network-policies/allow-dns
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
+  - ../../../../templates/network-policies/allow-from-nodes
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-ingress-lan
   - ./ingress-clients.yaml

--- a/kubernetes/apps/default/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/default/network-policies/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../templates/network-policies/allow-dns
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
+  - ../../../../templates/network-policies/allow-from-nodes
   - ../../../../templates/network-policies/allow-from-ingress
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-egress-open

--- a/kubernetes/apps/external-secrets/network-policies/app/ingress-webhook.yaml
+++ b/kubernetes/apps/external-secrets/network-policies/app/ingress-webhook.yaml
@@ -15,6 +15,8 @@ spec:
   ingress:
     - fromEntities:
         - kube-apiserver
+        - host
+        - remote-node
       toPorts:
         - ports:
             - port: "10250"

--- a/kubernetes/apps/media/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/media/network-policies/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../templates/network-policies/allow-dns
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
+  - ../../../../templates/network-policies/allow-from-nodes
   - ../../../../templates/network-policies/allow-from-ingress
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-egress-open

--- a/kubernetes/apps/observability/network-policies/app/ingress-webhook.yaml
+++ b/kubernetes/apps/observability/network-policies/app/ingress-webhook.yaml
@@ -13,6 +13,8 @@ spec:
   ingress:
     - fromEntities:
         - kube-apiserver
+        - host
+        - remote-node
       toPorts:
         - ports:
             - port: "10250"

--- a/kubernetes/apps/observability/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/observability/network-policies/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../templates/network-policies/allow-dns
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
+  - ../../../../templates/network-policies/allow-from-nodes
   - ../../../../templates/network-policies/allow-from-ingress
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-egress-open

--- a/kubernetes/templates/network-policies/allow-from-nodes/kustomization.yaml
+++ b/kubernetes/templates/network-policies/allow-from-nodes/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./policy.yaml

--- a/kubernetes/templates/network-policies/allow-from-nodes/policy.yaml
+++ b/kubernetes/templates/network-policies/allow-from-nodes/policy.yaml
@@ -1,0 +1,19 @@
+---
+# Allow ingress from the cluster nodes themselves (Cilium host/remote-node
+# identities). REQUIRED in any namespace that serves NodePort/LoadBalancer
+# traffic: LB/NodePort flows SNAT through a node and arrive carrying the
+# node's identity — Cilium ipBlock CIDR rules deliberately NEVER match node
+# identities, so an allow-ingress-lan ipBlock alone silently drops every
+# LB-fronted LAN client (discovered live 2026-08-09: MQTT clients and the
+# CNPG admission webhook). Health-check probes (kubelet) also ride on the
+# host identity.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-from-nodes
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node


### PR DESCRIPTION
Two live breakages from phase 4, both the same Cilium identity gotcha:
NodePort/LoadBalancer flows SNAT through a node and arrive as the
remote-node identity, which ipBlock CIDR rules deliberately never match —
so allow-ingress-lan silently dropped every LB-fronted LAN client (MQTT
clients observed dropping in hubble). Likewise apiserver->webhook calls
crossing nodes arrive as remote-node, not kube-apiserver; cert-manager's
webhook only survived by sharing a node with an apiserver (implicit host
allow).

New allow-from-nodes base (host + remote-node) wired into the four
LB-serving namespaces, and every apiserver-webhook CNP gains host +
remote-node entities.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
