### PR TITLE
fix(renovate): only propose stable Ceph releases (x.2.z)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -167,6 +167,24 @@
       dependencyDashboardApproval: true,
     },
     {
+      description: [
+        // Ceph tags encode maturity in the minor: x.0.z = dev, x.1.z = RC,
+        // x.2.z = stable. Renovate's docker versioning can't tell these apart,
+        // so it proposes RCs (e.g. v21.1.0 in #1218) as ordinary majors.
+        // Only allow stable x.2.z tags. Majors still arrive as PRs for manual
+        // review — keep this mgr-maintenance CLI image on the same major as
+        // the CephCluster daemons, which upgrade via the Rook chart, not here.
+        'ceph: stable releases only (x.2.z; x.1.z is RC, x.0.z is dev)',
+      ],
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'quay.io/ceph/ceph',
+      ],
+      allowedVersions: '/^v\\d+\\.2\\.\\d+$/',
+    },
+    {
       matchDatasources: [
         'helm',
       ],


### PR DESCRIPTION
Renovate proposed the Ceph v21.1.0 **release candidate** (#1218) as an ordinary major bump. Ceph encodes release maturity in the minor version: x.0.z = dev, x.1.z = RC, x.2.z = stable.

This adds a packageRule restricting `quay.io/ceph/ceph` to stable `x.2.z` tags (`allowedVersions: /^v\d+\.2\.\d+$/`), mirroring the existing emqx-operator hold pattern. Majors still arrive as PRs for manual review — the mgr-maintenance CLI image should track the CephCluster daemon major (currently v20.2.2), which upgrades via the Rook chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)