### PR TITLE
feat(devcontainer): add pinned helmfile v1.7.3 (helm 4 prep)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,6 +24,8 @@ ARG BWS_VERSION=v2.1.0
 ARG KUBECTL_VERSION=v1.36.3
 # renovate: datasource=github-releases depName=helm/helm
 ARG HELM_VERSION=v3.21.3
+# renovate: datasource=github-releases depName=helmfile/helmfile
+ARG HELMFILE_VERSION=v1.7.3
 # renovate: datasource=github-releases depName=stern/stern
 ARG STERN_VERSION=v1.34.0
 # renovate: datasource=github-releases depName=cli/cli
@@ -87,6 +89,9 @@ RUN set -eux \
     # helm
     && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
     && chmod +x /usr/local/bin/helm \
+    # helmfile
+    && curl -fsSL "https://github.com/helmfile/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION#v}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin helmfile \
+    && chmod +x /usr/local/bin/helmfile \
     # stern
     && curl -fsSL "https://github.com/stern/stern/releases/download/${STERN_VERSION}/stern_${STERN_VERSION#v}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin stern \
     && chmod +x /usr/local/bin/stern \


### PR DESCRIPTION
Adds helmfile `v1.7.3` to the devcontainer, pinned and Renovate-tracked via the existing regex manager.

Until now `task bootstrap:apps` depended on a rolling helmfile from the workstation Brewfile/Archfile — the devcontainer had helm but no helmfile. Pinning both together makes the bootstrap toolchain reproducible and unblocks helm 4:

- helmfile has supported Helm 4 since v1.5.x; v1.7.1+ bundles support for helm v4.2.3 (the version #1219 proposes)
- Verified locally: `helmfile template` over `kubernetes/bootstrap/helmfile.yaml` with helm v4.2.3 + helmfile v1.7.3 renders all 5 releases cleanly (78k lines, exit 0)

Follow-up: merge #1219 (helm v4.2.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)