### PR TITLE
feat(github-release)!: Update helm/helm to v4.2.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ ARG BWS_VERSION=v2.1.0
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
 ARG KUBECTL_VERSION=v1.36.3
 # renovate: datasource=github-releases depName=helm/helm
-ARG HELM_VERSION=v3.21.3
+ARG HELM_VERSION=v4.2.3
 # renovate: datasource=github-releases depName=helmfile/helmfile
 ARG HELMFILE_VERSION=v1.7.3
 # renovate: datasource=github-releases depName=stern/stern


### PR DESCRIPTION
Recreates #1219 (Renovate branch went CONFLICTING after #1231 added helmfile on adjacent Dockerfile lines).

helmfile v1.7.3 (now pinned in the devcontainer) supports helm 4 — verified by rendering `kubernetes/bootstrap/helmfile.yaml` with helm v4.2.3 + helmfile v1.7.3: all 5 releases template cleanly. Flux's helm-controller uses its own embedded helm SDK and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)