### PR TITLE
feat(actions-runner): deploy ARC gha-runner-scale-set for in-cluster CI runners

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: actions-runner-controller
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: actions-runner-controller
+  interval: 1h
+  values:
+    # Keeps the ServiceAccount name predictable so the runner scale set's
+    # controllerServiceAccount reference doesn't depend on Helm name mangling.
+    fullnameOverride: actions-runner-controller
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+  driftDetection:
+    mode: enabled
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: actions-runner-controller
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+    digest: sha256:3081ba15c41f0aa791058dedd2a7406fece24c9aeaa94956c268e5099427a452
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app actions-runner-controller
+  namespace: flux-system
+spec:
+  targetNamespace: actions-runner-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-ops-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secrets-manager
+  target:
+    name: home-ops-runner-secret
+    template:
+      engineVersion: v2
+      data:
+        # Classic PAT (or gh CLI OAuth token) with `repo` scope; repo-level
+        # runner registration. Swap to github_app_* keys if a GitHub App gets
+        # installed on the will-white account (the existing
+        # home-cluster-action-runner app is org-owned and can't see this repo).
+        github_token: "{{ .ACTIONS_RUNNER_GITHUB_TOKEN }}"
+  data:
+    - secretKey: ACTIONS_RUNNER_GITHUB_TOKEN
+      remoteRef:
+        key: ACTIONS_RUNNER_GITHUB_TOKEN

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-ops-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: home-ops-runner
+  interval: 1h
+  values:
+    githubConfigUrl: https://github.com/will-white/home-k8s-cluster
+    githubConfigSecret: home-ops-runner-secret
+    # `runs-on: home-ops-runner` in workflow files targets this scale set.
+    runnerScaleSetName: home-ops-runner
+    minRunners: 1
+    maxRunners: 5
+    # dind because flux-diff runs `docker://` container actions.
+    containerMode:
+      type: dind
+    # Explicit — the chart's cluster-lookup autodiscovery breaks flux-local
+    # (CI flux-diff) which templates without cluster access.
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system
+    template:
+      spec:
+        containers:
+          - name: runner
+            image: ghcr.io/actions/actions-runner:2.336.0
+            command: ["/home/runner/run.sh"]
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+    listenerTemplate:
+      spec:
+        containers:
+          - name: listener
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+  driftDetection:
+    mode: enabled
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-ops-runner
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+    digest: sha256:579e3a1bdf4032b3c3de3e9b0880a4a6d3c1989a67c06010f680c1cc49524d11
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-ops-runner
+  namespace: flux-system
+spec:
+  targetNamespace: actions-runner-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: actions-runner-controller
+    - name: external-secrets-stores
+  path: ./kubernetes/apps/actions-runner-system/home-ops-runner/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./actions-runner-controller/ks.yaml
+  - ./home-ops-runner/ks.yaml

--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: actions-runner-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    # Runner pods use Docker-in-Docker (the flux-diff workflow runs docker://
+    # container actions), and the dind sidecar requires privileged. Every pod
+    # in this namespace is a runner pod, so warn/audit privileged too — a
+    # restricted warn level would fire on every job.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
## What

New `actions-runner-system` namespace running GitHub's actions-runner-controller (gha-runner-scale-set stack, 0.14.2):

- **actions-runner-controller** — controller chart, `fullnameOverride` for a predictable ServiceAccount name.
- **home-ops-runner** — runner scale set for `will-white/home-k8s-cluster`, dind mode (flux-diff runs `docker://` container actions), min 1 / max 5 ephemeral runners, runner image pinned to 2.336.0.
- Auth: ExternalSecret → Bitwarden `ACTIONS_RUNNER_GITHUB_TOKEN` (repo-scope token). The existing `home-cluster-action-runner` GitHub App is owned by will-white-org and cannot serve this personal repo; the ExternalSecret documents the swap path.
- `controllerServiceAccount` set explicitly because the chart's cluster-lookup autodiscovery breaks flux-local templating in CI.
- Namespace enforces `privileged` PodSecurity (dind sidecar requirement).

## Rollout

1. Merge → controller reconciles; the scale set's ExternalSecret stays `SecretSyncedError` until `ACTIONS_RUNNER_GITHUB_TOKEN` is created in Bitwarden (owner action — classifier blocked the agent writing the token).
2. Once the secret exists, the listener registers `home-ops-runner` against the repo.
3. Follow-up PR flips workflow `runs-on` to `home-ops-runner` after the runner is verified online, alongside requiring approval for all outside-collaborator fork PRs (public repo + self-hosted runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)