### PR TITLE
chore(bootstrap): modernize helmDefaults for helm 4

### DIFF
--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -1,10 +1,10 @@
 ---
 helmDefaults:
+  cleanupOnFail: true
+  forceConflicts: true
   wait: true
   waitForJobs: true
   timeout: 600
-  recreatePods: true
-  force: true
 
 repositories:
   - name: cilium


### PR DESCRIPTION
Follow-up to the helm v4.2.3 move (#1231/#1232): drops legacy flags from the bootstrap helmfile.

- **Removed `recreatePods`** — helm 2 relic; the flag no longer exists (ignored/dead since helm 3)
- **Removed `force`** — blind resource replacement on re-bootstrap; risky and dropped by the current cluster-template
- **Added `cleanupOnFail` + `forceConflicts`** — matches onedr0p/cluster-template's current bootstrap helmDefaults (forceConflicts covers helm 4 server-side-apply conflicts)
- Kept `wait`/`waitForJobs`/`timeout: 600`

Validated: `yamllint` clean, and `helmfile template` over the bootstrap file with helm v4.2.3 + helmfile v1.7.3 renders all releases (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)