### PR TITLE
feat(ci): run CI workflows on in-cluster home-ops-runner scale set

### DIFF
--- a/.github/workflows/agent-validation.yml
+++ b/.github/workflows/agent-validation.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   validate-manifests:
     name: Validate Kubernetes Manifests
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     permissions:
       contents: read  # Only need to read repository contents
     steps:
@@ -28,15 +28,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Cache validation tools to speed up workflow
+      # Cache validation tools to speed up workflow. Tools live in ~/.local/bin
+      # (not /usr/local/bin): on the ARC runner image that path is root-owned,
+      # so a cache restore there fails. Key bumped to v2 to invalidate caches
+      # archived from the old absolute path.
       - name: Cache Validation Tools
         id: cache-tools
         uses: actions/cache@v6
         with:
-          path: /usr/local/bin
-          key: agent-validation-tools-${{ runner.os }}-v1
+          path: ~/.local/bin
+          key: agent-validation-tools-${{ runner.os }}-v2
           restore-keys: |
-            agent-validation-tools-${{ runner.os }}-
+            agent-validation-tools-${{ runner.os }}-v2
+
+      - name: Add tool dir to PATH
+        run: mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Validation Tools
         if: steps.cache-tools.outputs.cache-hit != 'true'
@@ -47,17 +53,19 @@ jobs:
           KUBECONFORM_VERSION="v0.8.0"
           curl -sL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz
           chmod +x kubeconform
-          sudo mv kubeconform /usr/local/bin/
+          mv kubeconform "$HOME/.local/bin/"
 
           echo "Installing kustomize..."
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.+)$
           KUSTOMIZE_VERSION="v5.8.1"
           curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | tar xz
           chmod +x kustomize
-          sudo mv kustomize /usr/local/bin/
+          mv kustomize "$HOME/.local/bin/"
 
-          echo "Installing yamllint..."
-          sudo apt-get update && sudo apt-get install -y yamllint
+      - name: Install yamllint
+        # Unconditional — apt installs to /usr/bin, which the tool cache never
+        # covered (hosted runners masked this by preinstalling yamllint).
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq yamllint
 
       - name: Verify Tool Installations
         run: |

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -14,7 +14,8 @@ concurrency:
 jobs:
   flux-diff:
     name: Flux Diff - ${{ matrix.resources }}
-    runs-on: ubuntu-latest
+    # docker:// container action — works on the dind-mode scale set
+    runs-on: home-ops-runner
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   gitleaks:
     name: Gitleaks
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -13,20 +13,26 @@ env:
 jobs:
   kubeconform:
     name: Kubeconform
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # Cache installed tools to speed up workflow
+      # Cache installed tools to speed up workflow. Tools live in ~/.local/bin
+      # (not /usr/local/bin): on the ARC runner image that path is root-owned,
+      # so a cache restore there fails. Key bumped to v2 to invalidate caches
+      # archived from the old absolute path.
       - name: Cache Tools
         id: cache-tools
         uses: actions/cache@v6
         with:
-          path: /usr/local/bin
-          key: kubeconform-tools-${{ runner.os }}-v1
+          path: ~/.local/bin
+          key: kubeconform-tools-${{ runner.os }}-v2
           restore-keys: |
-            kubeconform-tools-${{ runner.os }}-
+            kubeconform-tools-${{ runner.os }}-v2
+
+      - name: Add tool dir to PATH
+        run: mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Setup Workflow Tools
         if: steps.cache-tools.outputs.cache-hit != 'true'
@@ -36,19 +42,19 @@ jobs:
           KUBECONFORM_VERSION="v0.8.0"
           curl -sL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz
           chmod +x kubeconform
-          sudo mv kubeconform /usr/local/bin/
+          mv kubeconform "$HOME/.local/bin/"
           
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.+)$
           KUSTOMIZE_VERSION="v5.8.1"
           curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | tar xz
           chmod +x kustomize
-          sudo mv kustomize /usr/local/bin/
+          mv kustomize "$HOME/.local/bin/"
           
           # renovate: datasource=github-releases depName=fluxcd/flux2
           FLUX_VERSION="2.9.4"
           curl -sL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" | tar xz
           chmod +x flux
-          sudo mv flux /usr/local/bin/
+          mv flux "$HOME/.local/bin/"
 
       - name: Verify Tools
         run: |

--- a/.github/workflows/sops-check.yaml
+++ b/.github/workflows/sops-check.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   sops-check:
     name: SOPS Encryption Check
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -17,10 +17,11 @@ on:
 jobs:
   yamllint:
     name: yamllint
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     steps:
       - uses: actions/checkout@v7
       - name: Install yamllint
-        run: pipx install yamllint
+        # apt, not pipx — the ARC runner image has no python toolchain
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq yamllint
       - name: Lint
         run: yamllint -f github kubernetes/ .taskfiles/ Taskfile.yaml


### PR DESCRIPTION
## What

Switches the six validation workflows (kubeconform, yamllint, sops-check, gitleaks, flux-diff, agent-validation) from `ubuntu-latest` to the ARC **home-ops-runner** scale set deployed in #1233. `labeler`/`label-sync` stay on GitHub-hosted — they run on `pull_request_target` for fork events and belong off cluster hardware.

Runner-image adaptations (ghcr.io/actions/actions-runner is minimal):
- Tool caches move `/usr/local/bin` → `~/.local/bin` (root-owned path in the image would fail cache restore); cache keys bumped v1 → v2 so archives from the old absolute path don't restore.
- yamllint via apt instead of pipx (no python toolchain), and installed unconditionally in agent-validation — the cache-hit path previously depended on the hosted image preinstalling it.
- flux-diff's `docker://` container action is served by the scale set's dind mode.

## Safety

Fork-PR workflow approval was set to `all_external_contributors` before this flip — no outside fork executes on cluster runners without manual approval.

**Note the tradeoff:** merge-gating CI now depends on the cluster being healthy. If runners are down, jobs queue; revert this PR (or edit `runs-on`) to fall back to hosted runners.

This PR's own checks run on the new runner — green checks here are the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)