### PR TITLE
test: runner smoke test (do not merge)

### DIFF
--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -12,3 +12,6 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
     pod-security.kubernetes.io/audit: privileged
+
+# CI smoke test: exercises kubernetes/** path-filtered workflows on the
+# in-cluster runner scale set. PR is closed unmerged.


### PR DESCRIPTION
Throwaway PR to exercise the path-filtered workflows (kubeconform, yamllint, sops-check, flux-diff) on the in-cluster home-ops-runner scale set — flux-diff's docker:// action is the dind proof. Will be closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)