### PR TITLE
fix(talos-backup): set workingDir so etcd snapshots can be written

### DIFF
--- a/kubernetes/apps/system-upgrade/talos-backup/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/talos-backup/app/cronjob.yaml
@@ -31,6 +31,9 @@ spec:
           containers:
             - name: talos-backup
               image: ghcr.io/siderolabs/talos-backup:v0.1.0-beta.3
+              # talos-backup writes the .snap.part temp file to its CWD, which
+              # defaults to / — unwritable as uid 1000.
+              workingDir: /tmp
               env:
                 - name: TALOSCONFIG
                   value: /var/run/secrets/talos.dev/config


### PR DESCRIPTION
The etcd disaster-backup CronJob added in #1210 has **never succeeded** (no `lastSuccessfulTime`). Every run fails with:

```
failed to take etcd snapshot: error creating temp file: open home-kubernetes-...snap.part: permission denied
```

talos-backup writes the snapshot temp file to its working directory, which defaults to `/` — unwritable under `runAsUser: 1000`. Fix: `workingDir: /tmp`, where an `emptyDir` is already mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)