### PR TITLE
fix(recyclarr): drop include templates deleted upstream in v8

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/media/recyclarr/app/resources/recyclarr.yml
@@ -13,9 +13,16 @@
 #   Best Available - Escape hatch for obscure films. SDTV floor, Remux-2160p cutoff.
 #
 # Recyclarr only manages custom format definitions and per-profile CF scores.
-# Profile structure (qualities allowed, cutoff, upgrade settings) is managed in the UI.
-# The TRaSH `quality-profile` templates are intentionally NOT included here so Recyclarr
-# will not recreate the old-named profiles ("WEB-1080p", "UHD Bluray + WEB", etc.).
+# Profile structure (qualities allowed, cutoff, upgrade settings) and quality
+# definitions (file-size limits) are managed in the UI — live instances have
+# hand-tuned sizes (no max caps), so no `quality_definition:` here or Recyclarr
+# would overwrite them.
+# No `include:` templates: upstream recyclarr/config-templates deleted its
+# includes registry in the v8 architecture (merged to master 2026-08-07), and
+# every CF this config cares about is already listed explicitly below —
+# `trash_ids` sync CF definitions straight from the TRaSH guides, no templates
+# needed. This also stops Recyclarr from recreating the old-named profiles
+# ("WEB-1080p", "UHD Bluray + WEB", etc.).
 
 sonarr:
   sonarr_main:
@@ -23,13 +30,6 @@ sonarr:
     api_key: !env_var SONARR_API_KEY
 
     delete_old_custom_formats: true
-
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-custom-formats-web-1080p
-      - template: sonarr-v4-custom-formats-web-2160p
-      - template: sonarr-quality-definition-anime
-      - template: sonarr-v4-custom-formats-anime
 
     custom_formats:
 ##################  HD / 4K / Best Available — shared  ##################
@@ -147,16 +147,13 @@ sonarr:
           - name: Anime
 
 ##################  TRaSH parity — release-group tiers, junk & tiebreakers  ##################
-      # Recyclarr's `include:` templates DEFINE these CFs but assign their scores to TRaSH's
-      # default profile names (WEB-1080p / WEB-2160p / UHD Bluray + WEB / Remux-1080p - Anime),
-      # which we renamed to HD / 4K / Anime / Best Available — so Recyclarr dropped every one of
-      # those scores (the "profile names ... do not exist" [WRN] lines in the sync log). The
-      # blocks below re-address them to OUR profiles at the TRaSH default score (no explicit
-      # `score:`), restoring full-guide behaviour: release-group tier ranking, junk penalties
-      # (x265-HD, upscaled, 3D, LQ-title, WEB-Scene), repack/proper, and streaming tiebreakers.
+      # The full-guide CF sets (release-group tier ranking, junk penalties, repack/proper,
+      # streaming tiebreakers) addressed to OUR profile names at the TRaSH default score
+      # (no explicit `score:`). TRaSH's stock guide assigns these to its default profile
+      # names (WEB-1080p / WEB-2160p / UHD Bluray + WEB / Remux-1080p - Anime), which we
+      # renamed to HD / 4K / Anime / Best Available.
       # "Best Available" gets the UNION of the 1080p + 2160p positive tiers so it ranks the best
       # release at ANY resolution — its whole purpose as the resolution-agnostic escape hatch.
-      # Generated from recyclarr/config-templates@master; re-sync when the includes are bumped.
       # Remux release-group tiers (TRaSH default scores)
       - trash_ids:
           - 9965a052eb87b0d10313b1cea89eb451 # Remux Tier 01
@@ -294,14 +291,6 @@ radarr:
     api_key: !env_var RADARR_API_KEY
 
     delete_old_custom_formats: true
-
-    include:
-      - template: radarr-quality-definition-movie
-      # UHD CF set is the most comprehensive 4K-tier definition pack.
-      - template: radarr-custom-formats-uhd-bluray-web
-      # 1080p CF set covers HD-tier formats.
-      - template: radarr-custom-formats-remux-web-1080p
-      - template: radarr-custom-formats-anime
 
     custom_formats:
 ##################  HD / 4K / Best Available — shared  ##################
@@ -450,16 +439,13 @@ radarr:
           - name: Anime
 
 ##################  TRaSH parity — release-group tiers, junk & tiebreakers  ##################
-      # Recyclarr's `include:` templates DEFINE these CFs but assign their scores to TRaSH's
-      # default profile names (WEB-1080p / WEB-2160p / UHD Bluray + WEB / Remux-1080p - Anime),
-      # which we renamed to HD / 4K / Anime / Best Available — so Recyclarr dropped every one of
-      # those scores (the "profile names ... do not exist" [WRN] lines in the sync log). The
-      # blocks below re-address them to OUR profiles at the TRaSH default score (no explicit
-      # `score:`), restoring full-guide behaviour: release-group tier ranking, junk penalties
-      # (x265-HD, upscaled, 3D, LQ-title, WEB-Scene), repack/proper, and streaming tiebreakers.
+      # The full-guide CF sets (release-group tier ranking, junk penalties, repack/proper,
+      # streaming tiebreakers) addressed to OUR profile names at the TRaSH default score
+      # (no explicit `score:`). TRaSH's stock guide assigns these to its default profile
+      # names (WEB-1080p / WEB-2160p / UHD Bluray + WEB / Remux-1080p - Anime), which we
+      # renamed to HD / 4K / Anime / Best Available.
       # "Best Available" gets the UNION of the 1080p + 2160p positive tiers so it ranks the best
       # release at ANY resolution — its whole purpose as the resolution-agnostic escape hatch.
-      # Generated from recyclarr/config-templates@master; re-sync when the includes are bumped.
       # Remux release-group tiers (TRaSH default scores)
       - trash_ids:
           - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/kubernetes/apps/media/recyclarr/app/resources/settings.yml
+++ b/kubernetes/apps/media/recyclarr/app/resources/settings.yml
@@ -1,12 +1,7 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/latest/settings-schema.json
 ---
-# Recyclarr 8.x auto-selects the `v8` branch of recyclarr/config-templates,
-# which currently has an empty includes registry. Pin to `master` (the
-# production branch maintained for current Recyclarr) so referenced template
-# IDs like `radarr-quality-definition-movie` resolve.
-resource_providers:
-  - name: config-templates-master
-    type: config-templates
-    clone_url: https://github.com/recyclarr/config-templates.git
-    reference: master
-    replace_default: true
+# No resource_providers override: this config uses no `include:` templates
+# (upstream recyclarr/config-templates deleted its includes registry in the v8
+# architecture, 2026-08-07), so the default providers are fine. CF definitions
+# sync directly from the TRaSH guides via trash_ids in recyclarr.yml.
+{}


### PR DESCRIPTION
Nightly recyclarr sync has failed since 2026-08-07:

```
[ERR] Exiting due to fatal error: Instance 'radarr_main': Unable to find include template with name 'radarr-quality-definition-movie'
```

Upstream merged the v8 architecture into `master`, deleting the entire `includes/` registry — the master pin in settings.yml (added to dodge the empty v8 branch) no longer protects.

**Migration** (no legacy pin):
- Remove both `include:` blocks. They only (a) set `quality_definition` type and (b) defined CFs whose scores targeted TRaSH's default profile names — already dropped as warnings because our profiles are renamed (HD / 4K / Anime / Best Available). All meaningful CFs are listed explicitly via `trash_ids`, which sync definitions directly from the TRaSH guides.
- No `quality_definition:` replacement: live Sonarr/Radarr sizes are hand-tuned with no max caps (verified via API) — the include-based QD sync was not in effect, and adding one now would overwrite the UI-managed values.
- settings.yml provider pin removed (nothing uses config-templates anymore).
- `delete_old_custom_formats: true` will clean up the inert CFs the includes had created.

**Validation**: recyclarr 8.7.1 container parses the new config, initializes providers, and proceeds to instance contact (fails only on in-cluster DNS from outside — expected). yamllint + kubeconform clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)