### PR TITLE
fix(talos-backup): work around inverted USE_PATH_STYLE in beta.3

### DIFF
--- a/kubernetes/apps/system-upgrade/talos-backup/app/cronjob.yaml
+++ b/kubernetes/apps/system-upgrade/talos-backup/app/cronjob.yaml
@@ -47,8 +47,11 @@ spec:
                   value: etcd-snapshots
                 - name: CLUSTER_NAME
                   value: home-kubernetes
+                # v0.1.0-beta.3 inverts this flag (config parses == "false";
+                # fixed on master, unreleased) — "false" here MEANS path-style.
+                # Flip to "true" when bumping past beta.3.
                 - name: USE_PATH_STYLE
-                  value: "true"
+                  value: "false"
                 # Public half of the cluster Age key (age.key decrypts).
                 - name: AGE_X25519_PUBLIC_KEY
                   value: age17tn5txs6m4kdq4cfk9t7k5mcr58svuf0uwlrrmsxc9aslj4x9y4skkzs74


### PR DESCRIPTION
With #1239 merged the snapshot is taken and encrypted, but the upload dies on DNS: the S3 client uses virtual-hosted addressing (`volsync-backups.nas.internal`) even though `USE_PATH_STYLE=true` is set.

Root cause is upstream: [v0.1.0-beta.3's config parser](https://github.com/siderolabs/talos-backup/blob/v0.1.0-beta.3/pkg/config/service.go#L43) reads `UsePathStyle: os.Getenv(usePathStyleEnvVar) == "false"` — inverted. Master fixes it to `== "true"` but there has been no release since.

Workaround: set the env to `"false"` (which this image interprets as *enable path-style*), with a comment to flip it back on the next image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)