### PR TITLE
fix(netpol): allow homepage widgets and gatus probes across namespaces

### DIFF
--- a/kubernetes/apps/database/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/database/network-policies/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
   - ../../../../templates/network-policies/allow-from-nodes
+  - ../../../../templates/network-policies/allow-from-integrations
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-ingress-lan
   - ./ingress-clients.yaml

--- a/kubernetes/apps/default/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/default/network-policies/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
   - ../../../../templates/network-policies/allow-from-nodes
+  - ../../../../templates/network-policies/allow-from-integrations
   - ../../../../templates/network-policies/allow-from-ingress
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-egress-open

--- a/kubernetes/apps/media/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/media/network-policies/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
   - ../../../../templates/network-policies/allow-from-nodes
+  - ../../../../templates/network-policies/allow-from-integrations
   - ../../../../templates/network-policies/allow-from-ingress
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-egress-open

--- a/kubernetes/apps/observability/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/observability/network-policies/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../templates/network-policies/allow-kube-apiserver
   - ../../../../templates/network-policies/allow-intra-namespace
   - ../../../../templates/network-policies/allow-from-nodes
+  - ../../../../templates/network-policies/allow-from-integrations
   - ../../../../templates/network-policies/allow-from-ingress
   - ../../../../templates/network-policies/allow-from-monitoring
   - ../../../../templates/network-policies/allow-egress-open

--- a/kubernetes/templates/network-policies/allow-from-integrations/kustomization.yaml
+++ b/kubernetes/templates/network-policies/allow-from-integrations/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./policy.yaml

--- a/kubernetes/templates/network-policies/allow-from-integrations/policy.yaml
+++ b/kubernetes/templates/network-policies/allow-from-integrations/policy.yaml
@@ -1,0 +1,30 @@
+---
+# Allow the two cross-namespace "integration" clients into this namespace:
+#  - homepage (default): server-side dashboard widgets query app APIs
+#    directly (sonarr/radarr/qbittorrent stats, grafana/prometheus, ...)
+#  - gatus (observability): guarded health probes hit every app's endpoint
+# Both were silently broken by the phase-4 default-deny (homepage widgets
+# timed out cross-namespace, 2026-08-10). Scoped to the exact source pods,
+# not whole namespaces.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-integrations
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: homepage
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: gatus


### PR DESCRIPTION
Phase 4's default-deny silently broke the two legitimate cross-namespace
app-integration clients: homepage's server-side widgets (default ->
media/observability/database APIs) timed out, killing every service's
stats on the dashboard, and gatus's guarded probes (observability ->
media/default) were equally cut. New allow-from-integrations base admits
exactly those two source pods (pod+namespace selectors), wired into the
four locked app namespaces.

Note: the paperless widget's 401 is unrelated and PRE-DATES the
migrations — HOMEPAGE_VAR_PAPERLESS_API_KEY has never existed in any
secret (verified against the pre-flattening blob inventory).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
