### PR TITLE
fix(emqx): honor node taints in core topology spread constraint

### DIFF
--- a/kubernetes/apps/database/emqx/cluster/cluster.yaml
+++ b/kubernetes/apps/database/emqx/cluster/cluster.yaml
@@ -69,6 +69,18 @@ spec:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
+          # Honor (not the default Ignore) so the 3 NoSchedule-tainted
+          # control-plane nodes are not counted as spread domains. With Ignore
+          # they count as domains holding 0 core pods, which pins the global
+          # minimum at 0 -- so once all 5 workers hold one pod each, no worker
+          # can take a 2nd without skew reaching 2 > maxSkew.
+          #
+          # That deadlocks every image change: the operator does blue/green
+          # (new StatefulSet, all 3 new pods ready before retiring the old 3),
+          # so it needs a 6th pod scheduled while the old 3 still hold nodes.
+          # Hit for real on the 5.8.9 digest pin (#1242) -- 2 of 3 new pods
+          # scheduled, the 3rd sat Pending indefinitely.
+          nodeTaintsPolicy: Honor
           labelSelector:
             matchLabels:
               apps.emqx.io/instance: emqx


### PR DESCRIPTION
The core `topologySpreadConstraints` omitted `nodeTaintsPolicy`, which defaults to `Ignore`. That counts the 3 `NoSchedule`-tainted control-plane nodes as spread domains holding 0 core pods, pinning the global minimum at 0 — so once all 5 workers hold one pod each, no worker can accept a 2nd without skew reaching 2 > `maxSkew: 1`.

This deadlocks **every** emqx image change. The operator does blue/green: it creates a new StatefulSet and waits for all 3 new pods to be ready before retiring the old 3, which requires a 6th pod to schedule while the old 3 still occupy nodes.

Hit for real on the 5.8.9 digest pin (#1242) — 2 of 3 new pods scheduled and the 3rd sat `Pending` indefinitely:

```
0/8 nodes are available: 3 node(s) had untolerated taint(s),
5 node(s) didn't match pod topology spread constraints.
```

leaving the CR stuck in `CoreNodesProgressing` (`updateReplicas: 2`, `currentReplicas: 3`). No outage — all 5 running core nodes stayed in the `emqx-listeners` endpoints.

`Honor` excludes the tainted control-planes from domain counting, so the minimum becomes 1 and the 6th pod schedules at skew 1.

## Verification
- `yamllint kubernetes/apps/database/emqx` — clean
- `kustomize build` renders the field correctly
- Confirmed the live `emqxes.apps.emqx.io` v2beta1 CRD schema carries `nodeTaintsPolicy`, so it is not silently pruned by the operator's embedded pod schema

## Expected on merge
The operator sees a changed pod template and creates a third StatefulSet, garbage-collecting the stale intermediate one. Expect brief extra pod churn before the core set settles at 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)