### PR TITLE
fix: Intel schematic drift, GPU alerting, discovery log spam

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -56,8 +56,13 @@ tasks:
       - talosctl --nodes {{.HOSTNAME}} health --wait-timeout=10m --server=false
       - task: up
     vars:
+      # Schematic comes from talconfig.yaml (git), NOT the node's
+      # extensions.talos.dev/schematic annotation: a node running a stale
+      # schematic would otherwise re-pin itself forever, and extension
+      # changes committed to git would silently never roll out (this is how
+      # the 2026-08-09 v1.13.8 upgrade missed the nut-client extension).
       TALOS_SCHEMATIC_ID:
-        sh: kubectl get node {{.HOSTNAME}} --output=jsonpath='{.metadata.annotations.extensions\.talos\.dev/schematic}'
+        sh: yq '.nodes[] | select(.hostname == "{{.HOSTNAME}}") | .talosImageURL | split("/") | .[-1]' {{.TALHELPER_CONFIG_FILE}}
       TALOS_SECUREBOOT:
         sh: talosctl --nodes {{.HOSTNAME}} get securitystate --output=jsonpath='{.spec.secureBoot}'
       TALOS_VERSION:
@@ -66,10 +71,11 @@ tasks:
       vars: [HOSTNAME]
     preconditions:
       - curl -fsSL -o /dev/null --fail https://github.com/siderolabs/talos/releases/tag/{{.TALOS_VERSION}}
+      - yq --exit-status '.nodes[] | select(.hostname == "{{.HOSTNAME}}") | .talosImageURL' {{.TALHELPER_CONFIG_FILE}} >/dev/null
       - talosctl --nodes {{.HOSTNAME}} get machineconfig &>/dev/null
       - talosctl config info &>/dev/null
       - test -f {{.TALOSCONFIG}}
-      - which kubectl talosctl yq
+      - which talosctl yq
 
   upgrade-k8s:
     desc: Upgrade Kubernetes

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/prometheusrule.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/prometheusrule.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: intel-device-plugin-rules
+spec:
+  groups:
+    - name: intel-device-plugin.rules
+      rules:
+        - alert: IntelGPUNodeResourceZero
+          annotations:
+            summary: Node {{ $labels.node }} advertises zero gpu.intel.com/i915 devices
+            description: >-
+              Node {{ $labels.node }} has been advertising 0 allocatable
+              gpu.intel.com/i915 for more than 15 minutes. A short window of 0 is
+              normal right after a node boots (extended resources reset until the
+              intel-gpu-plugin pod re-registers with the kubelet); sustained 0 means
+              the plugin pod is failing on that node, or the node was
+              installed/upgraded with a Talos image whose schematic is missing the
+              siderolabs/i915 extension. Check the intel-gpu-plugin DaemonSet pod on
+              the node and `talosctl -n <node> get extensions`; the node schematic
+              must match the one pinned in kubernetes/bootstrap/talos/talconfig.yaml.
+          expr: kube_node_status_allocatable{resource="gpu_intel_com_i915"} == 0
+          for: 15m
+          labels:
+            severity: critical
+        - alert: IntelGPUResourceAbsent
+          annotations:
+            summary: No node in the cluster advertises gpu.intel.com/i915
+            description: >-
+              The gpu.intel.com/i915 allocatable metric is absent from every node
+              for more than 15 minutes. Either the intel-device-plugin stack is
+              down cluster-wide (operator or GpuDevicePlugin CR deleted, NFD labels
+              gone) or kube-state-metrics is not reporting. GPU workloads (Frigate)
+              cannot schedule while this fires.
+          expr: absent(kube_node_status_allocatable{resource="gpu_intel_com_i915"})
+          for: 15m
+          labels:
+            severity: critical

--- a/kubernetes/bootstrap/talos/patches/global/cluster-discovery.yaml
+++ b/kubernetes/bootstrap/talos/patches/global/cluster-discovery.yaml
@@ -1,7 +1,10 @@
 cluster:
+  # Discovery is fully disabled. The kubernetes registry cannot work on
+  # Kubernetes >=1.22 (the Node authorizer forbids nodes listing other
+  # nodes), so leaving it enabled only floods every node's kernel ring
+  # buffer with KubernetesPullController RBAC errors — it rotated real
+  # boot logs out of dmesg. The external service registry
+  # (discovery.talos.dev) stays off by choice; re-enable it instead of
+  # this if `talosctl get members` / KubeSpan are ever wanted.
   discovery:
-    registries:
-      kubernetes:
-        disabled: false
-      service:
-        disabled: true
+    enabled: false


### PR DESCRIPTION
## What

Three fixes from the Intel vPro/GPU flakiness investigation:

1. **`talos:upgrade-node` now sources the schematic from talconfig.yaml (git), not the node's own annotation.** The annotation approach re-pinned whatever a node already ran, so schematic changes in git silently never rolled out — the 2026-08-09 v1.13.8 upgrade kept all 8 nodes on `4ac502d0` (no `nut-client`) while git pins `f3350e61`. Verified both IDs against the Image Factory API; the only delta is `siderolabs/nut-client`.
2. **PrometheusRule for Intel GPU resources**: alerts when any node advertises 0 allocatable `gpu.intel.com/i915` for >15m, or when the resource is absent cluster-wide. Prometheus history shows zeros only during the Aug 9 power-up boots — this makes any future silent drop visible instead of surfacing as "Frigate won't schedule".
3. **Disable Talos cluster discovery** (kubernetes registry can't work on k8s ≥1.22 — Node authorizer forbids nodes listing nodes). The resulting RBAC error spams every node's dmesg every few seconds and rotated real boot logs out of the ring buffer. The external service registry stays off (existing choice); flip that on instead if `talosctl get members`/KubeSpan are ever wanted. Machine-config generation validated with talhelper 3.1.16.

## Follow-up (separate, cluster ops — not in this PR)

- Re-apply machine configs (picks up discovery change + stages nut-client upsmon config)
- Rolling node upgrade to `f3350e61` (delivers nut-client → working UPS shutdown)
- Remove stale `gpu.intel.com/i915_monitoring: 0` from node statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)