### PR TITLE
feat(cloudnative-pg): migrate backups to barman-cloud plugin

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease-barman-plugin.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease-barman-plugin.yaml
@@ -1,0 +1,39 @@
+---
+# CNPG-I plugin that replaces the deprecated in-tree barmanObjectStore
+# backup integration (removed upstream in CNPG 1.31). Must live in the same
+# namespace as the operator, which discovers it via the barman-cloud
+# Service (gRPC :9090, mTLS via cert-manager).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plugin-barman-cloud
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: plugin-barman-cloud
+      version: 0.7.1
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: flux-system
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    crds:
+      create: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+  driftDetection:
+    mode: enabled

--- a/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -2,3 +2,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./helmrelease-barman-plugin.yaml

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -23,27 +23,17 @@ spec:
       memory: 4Gi
   monitoring:
     enablePodMonitor: true
-  backup:
-    # Relaxed 30d -> 90d after Ceph capacity expansion (~3.6TiB, ~6% used).
-    retentionPolicy: 90d
-    barmanObjectStore: &barmanObjectStore
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: s3://cloudnative-pg/
-      endpointURL: http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc:80
-      # Note: serverName version needs to be incremented
-      # when recovering from an existing cnpg cluster
-      serverName: &currentCluster postgres16-v1
-      s3Credentials:
-        accessKeyId:
-          name: cloudnative-pg-secret
-          key: s3-access-key
-        secretAccessKey:
-          name: cloudnative-pg-secret
-          key: s3-secret-key
+  # WAL archiving + base backups via the barman-cloud CNPG-I plugin
+  # (in-tree barmanObjectStore is deprecated, removed in CNPG 1.31).
+  # Store config lives in objectstore.yaml; retentionPolicy moved there too.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: ceph-rgw
+        # Note: serverName version needs to be incremented
+        # when recovering from an existing cnpg cluster
+        serverName: postgres16-v1
   # bootstrap:
   #   # initdb:
   #   #   database: main
@@ -51,15 +41,17 @@ spec:
   #   #   secret:
   #   #     name: postgres-appuser-secret
   #   # Note: previousCluster is the OLD serverName you are recovering FROM.
-  #   # The live serverName above is postgres16-v1, so a recovery bumps the
-  #   # live one to postgres16-v2 and points this at postgres16-v1 (the
-  #   # DISASTER-RECOVERY.md runbook walks through this). The example below
-  #   # is written for that first recovery.
+  #   # The live serverName above (plugins[0].parameters.serverName) is
+  #   # postgres16-v1, so a recovery bumps the live one to postgres16-v2 and
+  #   # points this at postgres16-v1 (the DISASTER-RECOVERY.md runbook walks
+  #   # through this). The example below is written for that first recovery.
   #   recovery:
   #     source: &previousCluster postgres16-v1
   # # Note: externalClusters is needed when recovering from an existing cnpg cluster
   # externalClusters:
   #   - name: *previousCluster
-  #     barmanObjectStore:
-  #       <<: *barmanObjectStore
-  #       serverName: *previousCluster
+  #     plugin:
+  #       name: barman-cloud.cloudnative-pg.io
+  #       parameters:
+  #         barmanObjectName: ceph-rgw
+  #         serverName: *previousCluster

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster16.yaml
+  - ./objectstore.yaml
   - ./gatus.yaml
   - ./scheduledbackup.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -1,0 +1,35 @@
+---
+# Barman Cloud plugin object store: same Ceph RGW bucket + credentials the
+# in-tree barmanObjectStore used, so the existing archive carries over.
+# serverName intentionally lives on the Cluster plugin parameters (upstream
+# docs: it must be left empty here); retentionPolicy moved here from
+# Cluster.spec.backup.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: ceph-rgw
+spec:
+  # Relaxed 30d -> 90d after Ceph capacity expansion (~3.6TiB, ~6% used).
+  retentionPolicy: 90d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: s3://cloudnative-pg/
+    endpointURL: http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc:80
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: s3-access-key
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: s3-secret-key
+  instanceSidecarConfiguration:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -6,5 +6,8 @@ spec:
   schedule: "@daily"
   immediate: true
   backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   cluster:
     name: postgres16

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -10,6 +10,8 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets-stores
+    # plugin-barman-cloud's TLS certificates are issued by cert-manager
+    - name: cert-manager
   path: ./kubernetes/apps/database/cloudnative-pg/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/rook-ceph/rook-ceph/backup/DISASTER-RECOVERY.md
+++ b/kubernetes/apps/rook-ceph/rook-ceph/backup/DISASTER-RECOVERY.md
@@ -113,14 +113,17 @@ Restore is two layers: **object layer** (Garage → Ceph RGW) then **app layer**
 
 ### Layer 2a — CloudNativePG (Postgres)
 
-CNPG recovers from the barman store in the `cloudnative-pg` bucket. In
+CNPG recovers from the barman store in the `cloudnative-pg` bucket, via the
+barman-cloud plugin (`ObjectStore` `ceph-rgw` in `objectstore.yaml`; the
+in-tree `barmanObjectStore` was removed in CNPG 1.31). In
 `kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml`:
 
-1. Bump `serverName` (e.g. `postgres16-v1` → `postgres16-v2`) so the recovered
-   cluster writes to a new WAL prefix and does not clobber the archive it is
-   recovering from.
-2. Uncomment the `bootstrap.recovery` + `externalClusters` block; set
-   `previousCluster` to the OLD `serverName` (`postgres16-v1`).
+1. Bump `serverName` under `spec.plugins[0].parameters` (e.g. `postgres16-v1`
+   → `postgres16-v2`) so the recovered cluster writes to a new WAL prefix and
+   does not clobber the archive it is recovering from.
+2. Uncomment the `bootstrap.recovery` + `externalClusters` block (plugin-style,
+   pointing at the same `ceph-rgw` ObjectStore); set `previousCluster` to the
+   OLD `serverName` (`postgres16-v1`).
 3. Commit; let Flux create the cluster. It restores the base backup and replays
    WAL from `s3://cloudnative-pg/`.
 4. Once healthy, revert to the normal (non-recovery) spec in a follow-up commit.


### PR DESCRIPTION
## Why

In-tree \`barmanObjectStore\` backup support is **deprecated since CNPG 1.26 and removed in 1.31**. Our operator chart 0.29.0 already ships **CNPG 1.30**, so this migration is one minor version away from being forced. Doing it now, ahead of the image bump PR, also means the riskier change lands while the restore path is verified (and the follow-up image PR moves to `standard` images, which no longer contain the barman binary at all).

## What

- **`plugin-barman-cloud` HelmRelease** (chart 0.7.1) next to the operator in the `database` namespace (plugin discovery is namespace-local). TLS certs are issued by cert-manager → added `cert-manager` to the `cloudnative-pg` ks `dependsOn`.
- **`ObjectStore` `ceph-rgw`**: direct mapping of the old `barmanObjectStore` block — same RGW bucket, endpoint, credentials, bzip2 compression — so the existing archive carries over untouched. `retentionPolicy: 90d` moves here (plugin architecture puts retention on the ObjectStore). Sidecar `resources` set per repo convention.
- **Cluster `postgres16`**: `spec.backup` replaced with `spec.plugins[]` (`isWALArchiver: true`, `barmanObjectName: ceph-rgw`, `serverName: postgres16-v1` — unchanged, so no new WAL prefix and no recovery-bump needed). Commented recovery example rewritten plugin-style.
- **ScheduledBackup**: `method: plugin` + `pluginConfiguration`.
- **DISASTER-RECOVERY.md** Layer 2a updated (serverName now lives under `plugins[0].parameters`; recovery uses plugin-style `externalClusters`).

Network policies need no change: operator→plugin gRPC (:9090) is intra-namespace (`allow-intra-namespace`); the WAL-archiving sidecar runs inside the postgres pods so RGW egress is already covered by `allow-egress-rgw`. Alert rules use `cnpg_pg_stat_archiver_*` metrics, which remain valid under plugin-based archiving.

## Validation

- `kustomize build | kubeconform -strict` clean on both `app/` and `cluster/`
- `flux build ks --dry-run` clean for both Kustomizations
- `yamllint` clean

## Post-merge verification (before the image-bump PR)

1. Plugin pod Ready, cert issued: `kubectl -n database get pods,certificate`
2. Cluster reconciles, WAL archiving resumes: `kubectl cnpg status postgres16 -n database` (continuous archiving ✓)
3. On-demand backup completes: `kubectl cnpg backup postgres16 -n database -m plugin --plugin-name barman-cloud.cloudnative-pg.io` → `Backup` phase `completed`
4. New objects land under `s3://cloudnative-pg/postgres16-v1/` in RGW

🤖 Generated with [Claude Code](https://claude.com/claude-code)