### PR TITLE
chore(cloudnative-pg): bump postgres 16.6-2 → 16.14-standard-bookworm

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -4,7 +4,9 @@ metadata:
   name: postgres16
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.6-2
+  # standard flavor (no barman binary — WAL archiving runs in the plugin
+  # sidecar); bookworm pinned to keep glibc/collation stable for indexes.
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.14-standard-bookworm
   primaryUpdateStrategy: unsupervised
   storage:
     size: 20Gi


### PR DESCRIPTION
## ⚠️ Merge order

**Draft until #1252 (barman-cloud plugin migration) is merged and verified in-cluster.** The new `standard` image flavor does not contain the barman-cloud binary — with the current in-tree `barmanObjectStore` config, WAL archiving would break on this image. After #1252, archiving runs in the plugin sidecar and the binary is no longer needed in the postgres image.

## What / why

- `16.6-2` → `16.14-standard-bookworm`: five minors of Postgres CVE and bug fixes (16.6 is from Nov 2024; 16.14 released Aug 2026).
- CNPG retired the old `16.x-N` tag scheme after 16.4; images are now `<version>-<flavor>-<distro>`. Chosen:
  - **`standard`** flavor — the successor for general use; `system` (the old default's equivalent, with barman baked in) is deprecated upstream.
  - **`bookworm`** — same Debian base as the current image, so glibc (and therefore collation behavior) doesn't change. A distro jump to trixie changes glibc versions, which can silently corrupt text indexes; if we ever want trixie, that's a separate change with an `amcheck`/reindex plan.
- Rolling update: `primaryUpdateStrategy: unsupervised`, replicas restart first, then a switchover — brief primary failover expected.

## Validation

- `kustomize build | kubeconform -strict` clean, `yamllint` clean
- Tag `16.14-standard-bookworm` confirmed present on ghcr (built 2026-08-10)

## Post-merge verification

1. `kubectl cnpg status postgres16 -n database` — all 3 instances back on the new image, WAL archiving still ✓
2. First `ScheduledBackup` after the bump completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)