### PR TITLE
feat(cloudnative-pg): switch cluster16 to ImageCatalog

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -4,9 +4,11 @@ metadata:
   name: postgres16
 spec:
   instances: 3
-  # standard flavor (no barman binary — WAL archiving runs in the plugin
-  # sidecar); bookworm pinned to keep glibc/collation stable for indexes.
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.14-standard-bookworm
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ImageCatalog
+    name: postgresql
+    major: 16
   primaryUpdateStrategy: unsupervised
   storage:
     size: 20Gi

--- a/kubernetes/apps/database/cloudnative-pg/cluster/imagecatalog.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/imagecatalog.yaml
@@ -1,0 +1,17 @@
+---
+# Postgres images for cluster16's imageCatalogRef. The `image:` key (unlike
+# Cluster.spec.imageName, which no Renovate manager matches — how 16.6 sat
+# stale for 20 months) is picked up by Renovate's kubernetes manager, so
+# minors arrive as normal PRs. A future major upgrade = add the new major
+# here and bump imageCatalogRef.major (CNPG >=1.26 runs pg_upgrade
+# declaratively, offline in-place).
+# standard flavor (no barman binary — WAL archiving runs in the plugin
+# sidecar); bookworm pinned to keep glibc/collation stable for indexes.
+apiVersion: postgresql.cnpg.io/v1
+kind: ImageCatalog
+metadata:
+  name: postgresql
+spec:
+  images:
+    - major: 16
+      image: ghcr.io/cloudnative-pg/postgresql:16.14-standard-bookworm

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ./cluster16.yaml
   - ./objectstore.yaml
+  - ./imagecatalog.yaml
   - ./gatus.yaml
   - ./scheduledbackup.yaml
   - ./prometheusrule.yaml


### PR DESCRIPTION
## What

Replaces `Cluster.spec.imageName` with an `ImageCatalog` + `imageCatalogRef` (`major: 16`). **No image change** — same `16.14-standard-bookworm` as #1253, so merging this causes no additional rollout beyond the one #1253 already triggers.

## Why

- **This is what was keeping Postgres stale.** No Renovate manager matches the `imageName:` key (the `kubernetes` manager only extracts the literal `image:` key), which is how `16.6-2` went 20 months without a bump PR. The catalog's `spec.images[].image` field is picked up natively — no renovate.json5 changes needed — and the repo-wide `pinDigests` rule will digest-pin it like every other image (expect a pin PR after merge).
- **Cheaper majors later**: a 16 → 17/18 upgrade becomes "add catalog entry, bump `imageCatalogRef.major`" — CNPG ≥1.26 then runs a declarative offline in-place `pg_upgrade`.

## Stacking

Based on `chore/cnpg-postgres-16.14` (#1253), so the diff stays minimal; GitHub will retarget to `main` when #1253 merges. Merge order: **#1252 → #1253 (verify) → this**. Draft until then.

## Validation

`kubeconform -strict`, `flux build ks --dry-run` (catalog renders, ref resolves), and `yamllint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)