### PR TITLE
ci: make workflow tool downloads fail loudly and retry

### DIFF
--- a/.github/workflows/agent-validation.yml
+++ b/.github/workflows/agent-validation.yml
@@ -47,20 +47,33 @@ jobs:
       - name: Install Validation Tools
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: |
-          set -e
+          set -euo pipefail
+
+          # Download to a file rather than piping curl into tar, and use
+          # --fail so an HTTP error is a curl error instead of an error page
+          # being handed to gzip. GitHub's release CDN intermittently 503s
+          # (seen 2026-08-12), which under the old `curl -sL | tar xz` showed
+          # up as a misleading "gzip: stdin: not in gzip format" and failed
+          # the whole run on a cache miss. --retry-all-errors covers 5xx.
+          install_tool() {
+            local url="$1" name="$2" archive
+            archive="$(mktemp)"
+            curl -sSfL --retry 5 --retry-delay 3 --retry-all-errors -o "$archive" "$url"
+            tar xzf "$archive" "$name"
+            rm -f "$archive"
+            chmod +x "$name"
+            mv "$name" "$HOME/.local/bin/"
+          }
+
           echo "Installing kubeconform..."
           # renovate: datasource=github-releases depName=yannh/kubeconform
           KUBECONFORM_VERSION="v0.8.0"
-          curl -sL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz
-          chmod +x kubeconform
-          mv kubeconform "$HOME/.local/bin/"
+          install_tool "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" kubeconform
 
           echo "Installing kustomize..."
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.+)$
           KUSTOMIZE_VERSION="v5.8.1"
-          curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | tar xz
-          chmod +x kustomize
-          mv kustomize "$HOME/.local/bin/"
+          install_tool "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" kustomize
 
       - name: Install yamllint
         # Unconditional — apt installs to /usr/bin, which the tool cache never

--- a/.github/workflows/agent-validation.yml
+++ b/.github/workflows/agent-validation.yml
@@ -30,16 +30,18 @@ jobs:
 
       # Cache validation tools to speed up workflow. Tools live in ~/.local/bin
       # (not /usr/local/bin): on the ARC runner image that path is root-owned,
-      # so a cache restore there fails. Key bumped to v2 to invalidate caches
-      # archived from the old absolute path.
+      # so a cache restore there fails. Key bumped to v3 to force one cold
+      # install that exercises the hardened download path below (a warm cache
+      # skips that step entirely, which is how the 2026-08-12 CDN outage hit
+      # Kubeconform while this workflow passed on the same commit).
       - name: Cache Validation Tools
         id: cache-tools
         uses: actions/cache@v6
         with:
           path: ~/.local/bin
-          key: agent-validation-tools-${{ runner.os }}-v2
+          key: agent-validation-tools-${{ runner.os }}-v3
           restore-keys: |
-            agent-validation-tools-${{ runner.os }}-v2
+            agent-validation-tools-${{ runner.os }}-v3
 
       - name: Add tool dir to PATH
         run: mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -20,16 +20,16 @@ jobs:
 
       # Cache installed tools to speed up workflow. Tools live in ~/.local/bin
       # (not /usr/local/bin): on the ARC runner image that path is root-owned,
-      # so a cache restore there fails. Key bumped to v2 to invalidate caches
-      # archived from the old absolute path.
+      # so a cache restore there fails. Key bumped to v3 to force one cold
+      # install that exercises the hardened download path below.
       - name: Cache Tools
         id: cache-tools
         uses: actions/cache@v6
         with:
           path: ~/.local/bin
-          key: kubeconform-tools-${{ runner.os }}-v2
+          key: kubeconform-tools-${{ runner.os }}-v3
           restore-keys: |
-            kubeconform-tools-${{ runner.os }}-v2
+            kubeconform-tools-${{ runner.os }}-v3
 
       - name: Add tool dir to PATH
         run: mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -37,24 +37,35 @@ jobs:
       - name: Setup Workflow Tools
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: |
-          set -e
+          set -euo pipefail
+
+          # Download to a file rather than piping curl into tar, and use
+          # --fail so an HTTP error is a curl error instead of an error page
+          # being handed to gzip. GitHub's release CDN intermittently 503s
+          # (seen 2026-08-12), which under the old `curl -sL | tar xz` showed
+          # up as a misleading "gzip: stdin: not in gzip format" and failed
+          # the whole run on a cache miss. --retry-all-errors covers 5xx.
+          install_tool() {
+            local url="$1" name="$2" archive
+            archive="$(mktemp)"
+            curl -sSfL --retry 5 --retry-delay 3 --retry-all-errors -o "$archive" "$url"
+            tar xzf "$archive" "$name"
+            rm -f "$archive"
+            chmod +x "$name"
+            mv "$name" "$HOME/.local/bin/"
+          }
+
           # renovate: datasource=github-releases depName=yannh/kubeconform
           KUBECONFORM_VERSION="v0.8.0"
-          curl -sL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz
-          chmod +x kubeconform
-          mv kubeconform "$HOME/.local/bin/"
-          
+          install_tool "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" kubeconform
+
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.+)$
           KUSTOMIZE_VERSION="v5.8.1"
-          curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | tar xz
-          chmod +x kustomize
-          mv kustomize "$HOME/.local/bin/"
-          
+          install_tool "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" kustomize
+
           # renovate: datasource=github-releases depName=fluxcd/flux2
           FLUX_VERSION="2.9.4"
-          curl -sL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" | tar xz
-          chmod +x flux
-          mv flux "$HOME/.local/bin/"
+          install_tool "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" flux
 
       - name: Verify Tools
         run: |


### PR DESCRIPTION
## Why

On 2026-08-12 GitHub's release CDN returned **503 for every asset** for a few
minutes. The **Kubeconform** workflow happened to miss its tool cache in that
window and failed four consecutive runs, blocking a merge. **Agent Validation**
passed on the identical commit purely because its cache was warm — so the
failure looked manifest-specific when it was entirely environmental.

Two problems, both in the tool-download step:

- **`curl -sL` has no `--fail`**, so the 503 HTML error page was piped straight
  into `tar`. The run died with `gzip: stdin: not in gzip format`, which blames
  the archive instead of the network. That misdirection cost the most time.
- **No retry**, so an outage lasting seconds failed the whole run.

## What

Both `kubeconform.yaml` and `agent-validation.yml` get a shared `install_tool`
helper that:

- downloads to a file instead of piping into `tar`, with `-sSfL` so an HTTP
  error is a **curl** error;
- retries with `--retry 5 --retry-delay 3 --retry-all-errors` (plain `--retry`
  alone would not cover all the 5xx shapes seen);
- extracts the named binary, then installs it.

`flux-diff.yaml` needs no change — it does not curl any tooling.

## Validation

- Ran `install_tool` end-to-end for all three tools: kubeconform `v0.8.0`,
  kustomize `v5.8.1`, flux `v2.9.4` all install and report correct versions.
- Confirmed each tarball holds its binary at top level under the expected name
  (`tar tzf`), so extracting a named member is safe.
- Failure path: a bad version tag now exits **22** with
  `curl: (22) The requested URL returned error: 404` and never reaches the
  extract step — previously the same input produced the misleading gzip error.

## Trade-off

`--retry-all-errors` also retries 404s, so a genuinely wrong version tag takes
6 attempts (~15s, since 404s return immediately) before failing. Worth it to
survive transient 5xx; the failure message is now unambiguous either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)