### PR TITLE
feat(zwave-js-ui): add Z-Wave controller on slzb-ultima3

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - ./unifi/ks.yaml
   - ./zigbee2mqtt/ks.yaml
   - ./zigbee2mqtt-ota/ks.yaml
+  - ./zwave-js-ui/ks.yaml

--- a/kubernetes/apps/default/zwave-js-ui/app/externalsecret.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/externalsecret.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zwave-js-ui
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secrets-manager
+  target:
+    name: zwave-js-ui-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Z-Wave network security keys (32-char hex each)
+        KEY_S0_Legacy: "{{ .ZWAVE_KEY_S0_LEGACY }}"
+        KEY_S2_Unauthenticated: "{{ .ZWAVE_KEY_S2_UNAUTHENTICATED }}"
+        KEY_S2_Authenticated: "{{ .ZWAVE_KEY_S2_AUTHENTICATED }}"
+        KEY_S2_AccessControl: "{{ .ZWAVE_KEY_S2_ACCESS_CONTROL }}"
+        # Long Range (KEY_LR_S2_*) intentionally omitted — no LR devices.
+        # Safe to add later: a new key never disturbs already-included nodes.
+        # App
+        SESSION_SECRET: "{{ .ZWAVE_SESSION_SECRET }}"
+  data:
+    - secretKey: ZWAVE_KEY_S0_LEGACY
+      remoteRef:
+        key: ZWAVE_KEY_S0_LEGACY
+    - secretKey: ZWAVE_KEY_S2_UNAUTHENTICATED
+      remoteRef:
+        key: ZWAVE_KEY_S2_UNAUTHENTICATED
+    - secretKey: ZWAVE_KEY_S2_AUTHENTICATED
+      remoteRef:
+        key: ZWAVE_KEY_S2_AUTHENTICATED
+    - secretKey: ZWAVE_KEY_S2_ACCESS_CONTROL
+      remoteRef:
+        key: ZWAVE_KEY_S2_ACCESS_CONTROL
+    - secretKey: ZWAVE_SESSION_SECRET
+      remoteRef:
+        key: ZWAVE_SESSION_SECRET

--- a/kubernetes/apps/default/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/helmrelease.yaml
@@ -1,0 +1,149 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zwave-js-ui
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: zwave-js-ui
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  install:
+    remediation:
+      retries: 3
+  interval: 30m
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      zwave-js-ui:
+        annotations:
+          reloader.stakater.com/auto: 'true'
+        containers:
+          app:
+            env:
+              TZ: ${TIMEZONE}
+              PORT: 8091
+              STORE_DIR: /config
+              BACKUPS_DIR: /config/backups
+              ZWAVEJS_EXTERNAL_CONFIG: /config/.config-db
+              # Radio 3 (EFR32ZG23 Z-Wave add-on) exposed as a TCP socket by
+              # SLZB-OS — same remote-serial pattern as zigbee2mqtt on slzb-06m.
+              # Setting this also force-enables the Z-Wave driver.
+              ZWAVE_PORT: tcp://slzb-ultima3.internal:9638
+              # Declaratively manage the Z-Wave JS server + driver knobs that
+              # would otherwise only live in the UI's store/settings.json.
+              ZWAVE_EXTERNAL_SETTINGS: /settings/zwave.json
+            envFrom:
+              - secretRef:
+                  name: zwave-js-ui-secret
+            image:
+              repository: ghcr.io/zwave-js/zwave-js-ui
+              tag: 11.22.2@sha256:07b1a55e39f5cd309d60d5c33d93a3ff56b4bebd9ca73070ed8a03ec1e570381
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8091
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              # Deliberately probes the UI, not /health/zwave: gating the
+              # Service on the controller link would black-hole the web UI
+              # exactly when the SLZB link is down and you need it. Controller
+              # health is asserted by Gatus (GATUS_PATH) and the Loki rule.
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8091
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8091
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 60
+            resources:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 25m
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    ingress:
+      app:
+        annotations:
+          gethomepage.dev/enabled: 'true'
+          gethomepage.dev/group: Smart Home
+          gethomepage.dev/icon: zwavejs2mqtt.png
+          gethomepage.dev/name: Z-Wave
+          gethomepage.dev/description: Z-Wave controller
+        className: internal
+        hosts:
+          - host: zwave.${SECRET_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: zwave-js-ui
+      settings:
+        type: configMap
+        name: zwave-js-ui-settings
+        globalMounts:
+          - path: /settings/zwave.json
+            subPath: zwave.json
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        controller: zwave-js-ui
+        ports:
+          http:
+            port: 8091
+          # Z-Wave JS server websocket — this is what the Home Assistant
+          # Z-Wave integration connects to (ws://zwave-js-ui.default.svc:3000).
+          ws:
+            port: 3000
+  driftDetection:
+    mode: enabled

--- a/kubernetes/apps/default/zwave-js-ui/app/kustomization.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ../../../../templates/gatus/guarded
+  - ../../../../templates/volsync
+configMapGenerator:
+  - name: zwave-js-ui-settings
+    files:
+      - zwave.json=./resources/zwave-settings.json
+  - name: zwave-js-ui-loki-rules
+    files:
+      - zwave-js-ui.yaml=./lokirule.yaml
+    options:
+      labels:
+        loki_rule: "true"
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/default/zwave-js-ui/app/lokirule.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/lokirule.yaml
@@ -1,0 +1,14 @@
+---
+groups:
+  - name: zwave-js-ui
+    rules:
+      - alert: ZWaveJSUIControllerUnreachable
+        expr: |
+          sum(count_over_time({app="zwave-js-ui"} |~ "(?i)(unable to connect to zwave|failed to open the serial port|controller is not ready)"[5m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          category: logs
+        annotations:
+          app: "{{ $labels.app }}"
+          summary: "{{ $labels.app }} cannot reach the Z-Wave controller"

--- a/kubernetes/apps/default/zwave-js-ui/app/ocirepository.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zwave-js-ui
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+    digest: sha256:70a7cb6766eb468068c2c1700c8450253070dc671a9fbbd1a6346a66545e2b2b
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
+++ b/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
@@ -1,0 +1,11 @@
+{
+  "serverEnabled": true,
+  "serverHost": "0.0.0.0",
+  "serverPort": 3000,
+  "serverServiceDiscoveryDisabled": true,
+  "enableSoftReset": false,
+  "enableStatistics": false,
+  "logEnabled": true,
+  "logLevel": "info",
+  "logToFile": false
+}

--- a/kubernetes/apps/default/zwave-js-ui/ks.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zwave-js-ui
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./kubernetes/apps/default/zwave-js-ui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: default
+      GATUS_PORT: "8091"
+      # 200 only while the Z-Wave driver is connected to the SLZB socket
+      GATUS_PATH: /health/zwave
+      VOLSYNC_BOOTSTRAP_SOURCE_NAMESPACE: default
+      VOLSYNC_CAPACITY: 1Gi
+      # explicit: the claim's class is immutable once created
+      PVC_VOLSYNC_STORAGECLASS: ceph-block
+      # Network state only changes on include/exclude; daily backup is sufficient.
+      VOLSYNC_SCHEDULE: "0 4 * * *"


### PR DESCRIPTION
Adds `zwave-js-ui` in the `default` namespace, driving the SLZB-Ultima3's radio 3 (EFR32ZG23, Z-Wave 800) over TCP — the same remote-serial pattern `zigbee2mqtt` uses against `slzb-06m`, so no USB passthrough or `nodeSelector` is involved.

## Verification

- `kustomize build` + `kubeconform -strict` clean; repo-wide kubeconform clean
- `flux build ks --dry-run` renders
- `helm template` against app-template 5.0.1 produces a valid Deployment/Service/Ingress
- Controller reachable end to end: a Z-Wave `GetVersion` frame to `slzb-ultima3.internal:9638` ACKs and returns `Z-Wave 7.24`

## Notable choices

- **`ZWAVE_PORT`** pins the serial port via env rather than UI state; setting it also force-enables the driver.
- **`enableSoftReset: false`** — soft reset does not survive a network serial link.
- **Z-Wave JS server** (websocket `:3000`, what the Home Assistant integration connects to) is declared in an external settings file mounted from a ConfigMap, keeping it out of UI-only store state.
- **Readiness probes `/`, not `/health/zwave`**, on purpose: gating the Service on the controller link would black-hole the web UI exactly when the SLZB link is down. Gatus (`GATUS_PATH`) and the Loki rule assert controller health instead.
- **Network keys** come from Bitwarden via ExternalSecret (5 secrets created in the `home-cluster` project). Long Range keys are omitted for now — adding a key later never disturbs already-included nodes, whereas changing one breaks them.

## Follow-up after merge

Only remaining setup is adding the Home Assistant Z-Wave integration pointed at `ws://zwave-js-ui.default.svc.cluster.local:3000`. The volsync bootstrap will find no existing Kopia snapshots on first reconcile, which is expected for a new app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)