### PR TITLE
feat(zwave-js-ui): advertise the Z-Wave JS server over mDNS

### DIFF
--- a/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
+++ b/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
@@ -2,7 +2,7 @@
   "serverEnabled": true,
   "serverHost": "0.0.0.0",
   "serverPort": 3000,
-  "serverServiceDiscoveryDisabled": true,
+  "serverServiceDiscoveryDisabled": false,
   "enableSoftReset": false,
   "enableStatistics": false,
   "logEnabled": true,


### PR DESCRIPTION
Flips `serverServiceDiscoveryDisabled` to `false` so zwave-js-ui advertises `_zwave-js-server._tcp.local.`, which is the service type Home Assistant's `zwave_js` integration declares for zeroconf discovery.

Whether HA actually picks it up is the open question this settles: `zwave-js-ui` runs on the pod network while `home-assistant` runs `hostNetwork: true`, and mDNS is link-local multicast that doesn't cross Cilium's overlay onto the host LAN. My expectation is that HA still won't see it — testing rather than asserting.

Connectivity is unaffected either way. HA has `dnsPolicy: ClusterFirstWithHostNet`, so it resolves and reaches `ws://zwave-js-ui.default.svc.cluster.local:3000` regardless of discovery.

If discovery doesn't work, the follow-up decision is whether to revert this (keeping the endpoint explicit) or leave the advertisement on as harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)