### PR TITLE
fix(zwave-js-ui): disable mDNS advertisement again, record why

### DIFF
--- a/kubernetes/apps/default/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/helmrelease.yaml
@@ -41,6 +41,18 @@ spec:
               ZWAVE_PORT: tcp://slzb-ultima3.internal:9638
               # Declaratively manage the Z-Wave JS server + driver knobs that
               # would otherwise only live in the UI's store/settings.json.
+              #
+              # serverServiceDiscoveryDisabled is true in there on purpose, and
+              # it was measured, not assumed: HA's zwave_js integration does
+              # declare zeroconf discovery for _zwave-js-server._tcp.local., but
+              # with the advertisement enabled, a 12s browse from inside the
+              # home-assistant pod found nothing, while the same browse saw 19
+              # other services on the LAN (incl. the SLZB itself). HA runs
+              # hostNetwork; this pod does not, and link-local multicast does
+              # not cross the overlay. Add the HA integration by hand against
+              # ws://zwave-js-ui.default.svc.cluster.local:3000 — reachable via
+              # ClusterFirstWithHostNet. Only an mDNS reflector or hostNetwork
+              # would change this; neither is worth it for one URL.
               ZWAVE_EXTERNAL_SETTINGS: /settings/zwave.json
             envFrom:
               - secretRef:

--- a/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
+++ b/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
@@ -2,7 +2,7 @@
   "serverEnabled": true,
   "serverHost": "0.0.0.0",
   "serverPort": 3000,
-  "serverServiceDiscoveryDisabled": false,
+  "serverServiceDiscoveryDisabled": true,
   "enableSoftReset": false,
   "enableStatistics": false,
   "logEnabled": true,


### PR DESCRIPTION
Reverts #1271 and documents the result.

#1271 enabled the Z-Wave JS server's mDNS advertisement to settle empirically whether Home Assistant would auto-discover it. **It does not.**

## Measurement

With the advertisement live (pod log: `DNS Service Discovery enabled`), a 12s browse for `_zwave-js-server._tcp.local.` from inside the `home-assistant` pod returned nothing.

Control, same pod and same zeroconf stack, other service types:

| Type | Found |
|---|---|
| `_http._tcp` | 12 — incl. `truenas`, `Brother MFC-9560CDW`, `SLZB-06M` |
| `_esphomelib._tcp` | 3 |
| `_hap._tcp` | 2 |
| `_googlecast._tcp` | 1 |
| `_printer._tcp` | 1 |

19 services across 5 types. So zeroconf works fine from HA — it just can't see this pod. HA runs `hostNetwork: true` and listens on the LAN; zwave-js-ui multicasts inside the pod network namespace; link-local multicast doesn't cross the Cilium overlay. The SLZB-06M appearing while zwave-js-ui doesn't is the clean illustration.

## Change

Advertisement back off, since it was reaching nobody and leaving it on implied discovery was possible here. The finding is recorded as a comment next to `ZWAVE_EXTERNAL_SETTINGS` in the HelmRelease — the settings file is JSON and can't carry it.

Connectivity is unchanged: HA reaches `ws://zwave-js-ui.default.svc.cluster.local:3000` via `ClusterFirstWithHostNet`. Only an mDNS reflector or moving the pod to `hostNetwork` would change the discovery result, and neither is worth it for one URL typed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)