### PR TITLE
feat(zwave-js-ui): add the Z-Wave Long Range security keys

### DIFF
--- a/kubernetes/apps/default/zwave-js-ui/app/externalsecret.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/externalsecret.yaml
@@ -19,8 +19,8 @@ spec:
         KEY_S2_Unauthenticated: "{{ .ZWAVE_KEY_S2_UNAUTHENTICATED }}"
         KEY_S2_Authenticated: "{{ .ZWAVE_KEY_S2_AUTHENTICATED }}"
         KEY_S2_AccessControl: "{{ .ZWAVE_KEY_S2_ACCESS_CONTROL }}"
-        # Long Range (KEY_LR_S2_*) intentionally omitted — no LR devices.
-        # Safe to add later: a new key never disturbs already-included nodes.
+        KEY_LR_S2_Authenticated: "{{ .ZWAVE_KEY_LR_S2_AUTHENTICATED }}"
+        KEY_LR_S2_AccessControl: "{{ .ZWAVE_KEY_LR_S2_ACCESS_CONTROL }}"
         # App
         SESSION_SECRET: "{{ .ZWAVE_SESSION_SECRET }}"
   data:
@@ -36,6 +36,12 @@ spec:
     - secretKey: ZWAVE_KEY_S2_ACCESS_CONTROL
       remoteRef:
         key: ZWAVE_KEY_S2_ACCESS_CONTROL
+    - secretKey: ZWAVE_KEY_LR_S2_AUTHENTICATED
+      remoteRef:
+        key: ZWAVE_KEY_LR_S2_AUTHENTICATED
+    - secretKey: ZWAVE_KEY_LR_S2_ACCESS_CONTROL
+      remoteRef:
+        key: ZWAVE_KEY_LR_S2_ACCESS_CONTROL
     - secretKey: ZWAVE_SESSION_SECRET
       remoteRef:
         key: ZWAVE_SESSION_SECRET


### PR DESCRIPTION
zwave-js-ui warns in the UI that the LR `S2_Authenticated` and `S2_AccessControl` keys are missing. Adding them.

These were deliberately left out in #1270 on the grounds that there were no Long Range devices, with the explicit note that adding them later is safe. That still holds: a previously *absent* key never disturbs already-included nodes — each node keeps using the security class it was granted at inclusion time. Only *changing* an existing key breaks devices, and nothing here is being changed. The four original keys and the session secret are untouched.

Both new keys were generated with `openssl rand -hex 16` and stored in Bitwarden SM (`home-cluster` project) as `ZWAVE_KEY_LR_S2_AUTHENTICATED` and `ZWAVE_KEY_LR_S2_ACCESS_CONTROL`. Values were never printed or logged; the creation script skips rather than overwrites if a key already exists.

After this, LR-capable devices can be included over Long Range instead of falling back to the classic mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)