### PR TITLE
fix(suwayomi): store downloaded chapters on the NAS, not the config PVC

### DIFF
--- a/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
@@ -50,7 +50,11 @@ spec:
               # Refresh each entry's own metadata (status/cover/description)
               # during the global update, not just its chapter list
               UPDATE_MANGA_INFO: "true"
-              DOWNLOADS_PATH: /media/manga
+              # NOTE: there is deliberately no DOWNLOADS_PATH here. The image's
+              # startup_script.sh only sed's a fixed allow-list of env vars into
+              # server.conf, and downloadsPath is not on it -- so setting it is a
+              # silent no-op and downloads land on the config PVC. The downloads
+              # directory is bind-mounted from the NAS instead (see persistence).
               # Route Cloudflare-challenged sources through the in-cluster
               # FlareSolverr (byparr) instance; only invoked when a source
               # actually returns a challenge, so otherwise a no-op
@@ -109,5 +113,10 @@ spec:
         path: /mnt/main/media
         globalMounts:
           - path: /media
+          # Keep the ~9G of downloaded chapters off the 10Gi config PVC: the
+          # data dir's default downloads/ location is served straight from the
+          # NAS, so files land in /mnt/main/media/manga/mangas/<source>/<title>/
+          - path: /home/suwayomi/.local/share/Tachidesk/downloads
+            subPath: manga
   driftDetection:
     mode: enabled


### PR DESCRIPTION
## Problem

suwayomi's 10Gi `ceph-filesystem` config PVC hit **92% (9.2G/10G)**.

`DOWNLOADS_PATH: /media/manga` in the HelmRelease is a **silent no-op**. The upstream image only translates a fixed allow-list of env vars into `server.conf` via `sed` in `/home/suwayomi/startup_script.sh`, and `downloadsPath` is not on that list (neither is `backupPath` nor `localSourcePath`). Live confirmation in the running pod:

```
server.downloadsPath = ""     # default: ""
```

So every chapter has been written to the data dir on the config PVC:

| Path | Size |
|---|---|
| `…/Tachidesk/downloads/mangas` (ceph-filesystem) | **9.0G** |
| everything else on the PVC (DB, cache, bin, webUI) | ~250M |
| `/media/manga` (NAS) | **empty** |

## Fix

Bind-mount the NAS manga directory over the data dir's default `downloads/` location, using a second `globalMounts` entry with `subPath` on the NFS volume that is already attached. This works regardless of the image's env-var handling, so it can't silently regress the way the env var did. The `DOWNLOADS_PATH` env is removed and replaced with a comment recording why it cannot work.

Chapters now land at `/mnt/main/media/manga/mangas/<source>/<title>/*.cbz` — so a Komga/Kavita library would point at `manga/mangas`.

Ceph RGW is not an option here: suwayomi has no S3 support.

Verified with `helm template` against app-template 5.0.1:

```yaml
volumeMounts:
- mountPath: /home/suwayomi/.local/share/Tachidesk
  name: config
- mountPath: /media
  name: media
- mountPath: /home/suwayomi/.local/share/Tachidesk/downloads
  name: media
  subPath: manga
```

## Data migration

The existing **9.0G / 766 files** were copied to the NAS *before* cutover (otherwise the new mount would shadow them and suwayomi would treat every chapter as un-downloaded). Verified byte-identical, including a delta pass to catch anything downloaded during the copy:

```
src files: 766  dst files: 766
src bytes: 9576222545  dst bytes: 9576222545
```

The now-orphaned copy on the PVC is left in place by this PR; it will be removed separately once the new mount is confirmed working, which is what actually reclaims the space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
