### PR TITLE
fix(zwave-js-ui): pin the RF region to USA (Long Range)

### DIFF
--- a/kubernetes/apps/default/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zwave-js-ui/app/helmrelease.yaml
@@ -53,6 +53,13 @@ spec:
               # ws://zwave-js-ui.default.svc.cluster.local:3000 — reachable via
               # ClusterFirstWithHostNet. Only an mDNS reflector or hostNetwork
               # would change this; neither is worth it for one URL.
+              #
+              # rf.region is pinned to 9 ("USA (Long Range)") in there. It is
+              # not cosmetic: nothing had ever set a region, so the ZG23 kept
+              # its firmware default and the controller was measured running on
+              # 11 ("Europe (Long Range)") -- 868.4MHz. Every inclusion attempt
+              # failed because US 908.4MHz devices are simply not audible on the
+              # EU band. Leave this set or the radio silently reverts to EU.
               ZWAVE_EXTERNAL_SETTINGS: /settings/zwave.json
             envFrom:
               - secretRef:

--- a/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
+++ b/kubernetes/apps/default/zwave-js-ui/app/resources/zwave-settings.json
@@ -1,4 +1,7 @@
 {
+  "rf": {
+    "region": 9
+  },
   "serverEnabled": true,
   "serverHost": "0.0.0.0",
   "serverPort": 3000,


### PR DESCRIPTION
## Symptom

Z-Wave inclusion never succeeds. The network has exactly **one node — the controller itself**. The logs show eight `Secure inclusion started → Inclusion stopped` cycles (19:32–19:42) and a Zooz ZAC36 Titan SmartStart entry provisioned then unprovisioned, with nothing ever joining.

## Root cause

The radio is on the wrong continent:

```
controller.get_rf_region -> 11   =   "Europe (Long Range)"   (868.4 MHz)
```

Nothing sets an RF region anywhere — not this repo, not the live `/config/settings.json` — so the Ultima's EFR32ZG23 keeps its firmware default, which is EU. The cluster is `America/Denver` and the device being included is a US 908.4 MHz Zooz ZAC36, which simply is not audible on the EU band.

Adding the LR security keys in #1273 could not have helped on its own; the radio still has to be on a US band.

## Fix

Set `rf.region = 9` (`"USA (Long Range)"`) in the external settings ConfigMap. `server/lib/externalSettings.js` maps `rf.region` onto `zwaveOptions.rf.region`, which the driver applies to the radio at startup:

```js
if (settings.rf.region !== undefined)
    rf.region = settings.rf.region;
...
if (typeof region === 'number') {
    zwaveOptions.rf.region = region;
}
```

Region **9** rather than **1** to match the LR keys already wired up in #1273. Safe to change: the network is empty, so there are no nodes to orphan.

The controller has `reloader.stakater.com/auto: 'true'`, so the pod restarts on the ConfigMap change and re-applies the region.

## The radio link was never the problem

Verified healthy while diagnosing:

- `ZWAVE_PORT` and the stored settings both `tcp://slzb-ultima3.internal:9638` → `192.168.5.109`, ESTABLISHED session in `/proc/net/tcp`
- `.109` self-identifies as an Ultima (`ambilight.ultLedMode`, PSRAM, LTE, three radio sockets)
- Controller node 1: Silicon Labs 700/800 Series, SDK 7.24.3, `supportsLongRange: true`, home ID `d4b936fb`
- Live `get_background_rssi` round-trip: `-90 / -102 / -102 / -92` dBm — uncacheable, so the driver is genuinely talking to the chip

Note for future debugging: the Ultima's `socket*_uptime` fields in `/ha_sensors` all read `0` while the link was demonstrably live, so they are not a usable health signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
